### PR TITLE
Add rolling temporal BM3Dv2 for CUDA and CUDA RTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ The `cpu` version does not require any external libraries but requires AVX2 supp
 
 - `bm3d.VAggregate` should be called after temporal filtering, as in `VapourSynth-BM3D`. Alternatively, you may use the `BM3Dv2()` interface for both spatial and temporal denoising in one step.
 
+- For CUDA and CUDA RTC, `BM3Dv2(radius > 0)` fuses the temporal BM3D passes and final aggregation on the GPU. The public `BM3D(radius > 0)` and `VAggregate` interfaces retain their existing intermediate-frame behavior.
+
+- `VAggregate(planes=...)` accepts each plane at most once. Plane indices must be non-negative and smaller than the number of planes in `src`.
+
 - The `_rtc` version has three additional experimental parameters:
 
     - bm_error_s: (string)
@@ -149,6 +153,10 @@ The `cpu` version does not require any external libraries but requires AVX2 supp
 GPU memory consumptions:
 
 `(ref ? 4 : 3) * (chroma ? 3 : 1) * (fast ? 4 : 1) * (2 * radius + 1) * size_of_a_single_frame`
+
+For the fused CUDA/RTC `BM3Dv2(radius > 0)` path:
+
+`(max((ref ? 2 : 1) * (4 * radius + 1), 2 * (2 * radius + 1)) + 2 * (2 * radius + 1)) * (chroma ? 3 : 1) * (fast ? 4 : 1) * size_of_a_single_frame`
 
 ## Compilation
 - The CMake configuration of `BM3DCUDA_RTC` links to NVRTC static library by default, which requires CUDA 11.5 or later.

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ The `cpu` version does not require any external libraries but requires AVX2 supp
 CUDA and CUDA RTC provide execution selection on `BM3Dv2`:
 
 ```python3
-{bm3dcuda, bm3dcuda_rtc}.BM3Dv2(clip[, ..., temporal_mode="fused", rolling_chunk=16])
+{bm3dcuda, bm3dcuda_rtc}.BM3Dv2(clip[, ..., temporal_mode="rolling", rolling_chunk=4, rolling_cache_chunks=1, rolling_cache_limit=16])
 ```
 
 - clip:
 
-    The input clip. Must be of 32 bit float format. Each plane is denoised separately if `chroma` is set to `False`. Data of unprocessed planes is undefined. Frame properties of the output clip are copied from it.
+    The input clip. Must be of 32 bit float format. Each plane is denoised separately if `chroma` is set to `False`. Data of unprocessed planes is undefined for the public intermediate-frame path; rolling `BM3Dv2` copies them from the source. Frame properties of the output clip are copied from it.
 
 - ref:
 
@@ -117,32 +117,49 @@ CUDA and CUDA RTC provide execution selection on `BM3Dv2`:
 
     Default `0`. (non-determinism)
 
-- temporal_mode, rolling_chunk:
+- temporal_mode, rolling_chunk, rolling_cache_chunks, rolling_cache_limit:
 
-    `temporal_mode` selects temporal execution for `radius > 0`. `"fused"`
-    is the default and retains the existing fused CUDA path. `"legacy"`
-    composes public `BM3D` and `VAggregate`. `"rolling"` uses one CUDA
-    stream and one resource set to build aligned output chunks; `fast` is
-    accepted in this mode for API compatibility but has no effect.
+    `temporal_mode` selects temporal execution for `radius > 0`. `"rolling"`
+    is the default and uses one CUDA stream and one resource set to build
+    aligned output chunks. `"legacy"` composes public `BM3D` and
+    `VAggregate`. These are the only accepted temporal modes. `fast` is
+    accepted in rolling mode for API compatibility but has no effect.
 
     `rolling_chunk` sets the rolling chunk size in the range `[1, 64]` and
-    defaults to `16`. It may only be supplied with `temporal_mode="rolling"`.
+    defaults to `4`. It may only be supplied with `temporal_mode="rolling"`.
     Rolling mode requires `radius > 0`.
+
+    `rolling_cache_chunks` sets the number of completed chunks retained in the
+    rolling output cache, in the range `[1, 64]`, and defaults to `1`. It may
+    only be supplied with `temporal_mode="rolling"`. A value greater than one
+    keeps an LRU cache of final VapourSynth frames for random access; it does
+    not allocate another CUDA resource, stream, or graph and does not add GPU
+    work on cache hits. The tradeoff is host frame memory proportional to
+    `rolling_chunk * rolling_cache_chunks` (plus normal VapourSynth frame
+    overhead).
+
+    `rolling_cache_limit` bounds adaptive cache growth in the range `[1, 64]`
+    and defaults to `16`. When `rolling_cache_chunks` is omitted, rolling
+    grows its cache up to this limit after repeated chunk reuse. Supplying
+    `rolling_cache_chunks` explicitly keeps a fixed cache size unless a larger
+    `rolling_cache_limit` is also requested.
 
 ## Notes
 
 - `bm3d.VAggregate` should be called after temporal filtering, as in `VapourSynth-BM3D`. Alternatively, you may use the `BM3Dv2()` interface for both spatial and temporal denoising in one step.
 
-- For CUDA and CUDA RTC, `BM3Dv2(radius > 0)` uses fused temporal BM3D and
+- For CUDA and CUDA RTC, `BM3Dv2(radius > 0)` uses rolling temporal BM3D and
   final GPU aggregation by default. The public `BM3D(radius > 0)` and
   `VAggregate` interfaces retain their existing intermediate-frame behavior.
 
 - CUDA rolling chunks are aligned by
   `floor(frame / rolling_chunk) * rolling_chunk`. The filter retains one
-  completed chunk of final VapourSynth frames. Requests inside that chunk are
-  cache hits; a request outside it recomputes and replaces the aligned chunk,
-  so alternating random-access requests can repeat work. A partial final chunk
-  uses replicated end frames internally and caches only valid output frames.
+  completed chunk of final VapourSynth frames by default. Requests inside that
+  cache are hits; a request outside it recomputes the aligned chunk. Set
+  `rolling_cache_chunks > 1` to retain several completed chunks in an LRU
+  cache and reduce repeated work for bounded random-access working sets. A
+  partial final chunk uses replicated end frames internally and caches only
+  valid output frames.
 
 - Rolling uploads one `rolling_chunk + 4 * radius` source slab (and one
   reference slab for final estimation), computes
@@ -151,9 +168,17 @@ CUDA and CUDA RTC provide execution selection on `BM3Dv2`:
   increase GPU accumulators, pinned staging memory, retained frame memory, and
   latency for a random-access miss.
 
+- For mostly linear rendering, `rolling_chunk=16, rolling_cache_chunks=1`
+  favors throughput. For interactive access or a small downstream temporal
+  window, `rolling_chunk=4, rolling_cache_chunks=2` is a lower-latency starting
+  point. Fully unpredictable random access can still cause rolling chunk
+  misses; increase `rolling_cache_limit` when the working set is bounded.
+
 - RTC rolling uses one device resource, one stream, and one Driver API graph.
-  A completed chunk is retained in a frame cache; cache misses stage the
-  source/reference halo, serialize graph execution, and replace the cache.
+  A completed chunk is retained in a frame cache by default; cache misses
+  stage the source/reference halo, serialize graph execution, and insert the
+  result into the bounded LRU cache. `rolling_cache_chunks` changes only the
+  number of retained final chunks.
   `fast` is accepted for API compatibility but does not change rolling's
   resource count. Partial final chunks cache only valid output frames.
 
@@ -194,15 +219,12 @@ GPU memory consumptions:
 
 `(ref ? 4 : 3) * (chroma ? 3 : 1) * (fast ? 4 : 1) * (2 * radius + 1) * size_of_a_single_frame`
 
-For the fused CUDA/RTC `BM3Dv2(radius > 0)` path:
-
-`(max((ref ? 2 : 1) * (4 * radius + 1), 2 * (2 * radius + 1)) + 2 * (2 * radius + 1)) * (chroma ? 3 : 1) * (fast ? 4 : 1) * size_of_a_single_frame`
-
-For the rolling CUDA `BM3Dv2(radius > 0)` path, one stream holds a
+For the rolling CUDA/RTC `BM3Dv2(radius > 0)` path, one stream holds a
 source slab, one `2 * radius + 1`-slice scratch result, and
 `rolling_chunk` weighted accumulators. Pinned host memory holds the source slab
-and normalized chunk outputs. The filter additionally retains one chunk of
-normal VapourSynth output frames.
+and normalized chunk outputs. The filter additionally retains
+`rolling_cache_chunks * rolling_chunk` normal VapourSynth output frames (or
+fewer for the final partial chunk).
 
 ## Compilation
 - The CMake configuration of `BM3DCUDA_RTC` links to NVRTC static library by default, which requires CUDA 11.5 or later.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ The `cpu` version does not require any external libraries but requires AVX2 supp
 {bm3dcuda, bm3dcuda_rtc, bm3dcpu}.BM3D(clip clip[, clip ref=None, float[] sigma=3.0, int[] block_step=8, int[] bm_range=9, int radius=0, int[] ps_num=2, int[] ps_range=4, bint chroma=False, int device_id=0, bool fast=True, int extractor_exp=0])
 ```
 
+Static CUDA also provides execution selection on `BM3Dv2`:
+
+```python3
+bm3dcuda.BM3Dv2(clip[, ..., temporal_mode="fused", rolling_chunk=16])
+```
+
 - clip:
 
     The input clip. Must be of 32 bit float format. Each plane is denoised separately if `chroma` is set to `False`. Data of unprocessed planes is undefined. Frame properties of the output clip are copied from it.
@@ -111,11 +117,43 @@ The `cpu` version does not require any external libraries but requires AVX2 supp
 
     Default `0`. (non-determinism)
 
+- temporal_mode, rolling_chunk: (static CUDA `BM3Dv2` only)
+
+    `temporal_mode` selects temporal execution for `radius > 0`. `"fused"`
+    is the default and retains the existing fused CUDA path. `"legacy"`
+    composes public `BM3D` and `VAggregate`. `"rolling"` uses one CUDA
+    stream and one resource set to build aligned output chunks; `fast` is
+    accepted in this mode for API compatibility but has no effect.
+
+    This experimental rolling mode is implemented only by the static
+    `bm3dcuda` plugin. The `bm3dcuda_rtc` plugin does not accept these two
+    options and continues to use its existing temporal implementation.
+
+    `rolling_chunk` sets the rolling chunk size in the range `[1, 64]` and
+    defaults to `16`. It may only be supplied with `temporal_mode="rolling"`.
+    Rolling mode requires `radius > 0`.
+
 ## Notes
 
 - `bm3d.VAggregate` should be called after temporal filtering, as in `VapourSynth-BM3D`. Alternatively, you may use the `BM3Dv2()` interface for both spatial and temporal denoising in one step.
 
-- For CUDA and CUDA RTC, `BM3Dv2(radius > 0)` fuses the temporal BM3D passes and final aggregation on the GPU. The public `BM3D(radius > 0)` and `VAggregate` interfaces retain their existing intermediate-frame behavior.
+- For CUDA and CUDA RTC, `BM3Dv2(radius > 0)` uses fused temporal BM3D and
+  final GPU aggregation by default. The public `BM3D(radius > 0)` and
+  `VAggregate` interfaces retain their existing intermediate-frame behavior.
+
+- Static CUDA rolling chunks are aligned by
+  `floor(frame / rolling_chunk) * rolling_chunk`. The filter retains one
+  completed chunk of final VapourSynth frames. Requests inside that chunk are
+  cache hits; a request outside it recomputes and replaces the aligned chunk,
+  so alternating random-access requests can repeat work. A partial final chunk
+  uses replicated end frames internally and caches only valid output frames.
+
+- Rolling uploads one `rolling_chunk + 4 * radius` source slab (and one
+  reference slab for final estimation), computes
+  `rolling_chunk + 2 * radius` temporal centers in order, and transfers only
+  normalized output frames to the host. Larger chunks amortize halo work but
+  increase GPU accumulators, pinned staging memory, retained frame memory, and
+  latency for a random-access miss.
 
 - `VAggregate(planes=...)` accepts each plane at most once. Plane indices must be non-negative and smaller than the number of planes in `src`.
 
@@ -157,6 +195,12 @@ GPU memory consumptions:
 For the fused CUDA/RTC `BM3Dv2(radius > 0)` path:
 
 `(max((ref ? 2 : 1) * (4 * radius + 1), 2 * (2 * radius + 1)) + 2 * (2 * radius + 1)) * (chroma ? 3 : 1) * (fast ? 4 : 1) * size_of_a_single_frame`
+
+For the rolling static CUDA `BM3Dv2(radius > 0)` path, one stream holds a
+source slab, one `2 * radius + 1`-slice scratch result, and
+`rolling_chunk` weighted accumulators. Pinned host memory holds the source slab
+and normalized chunk outputs. The filter additionally retains one chunk of
+normal VapourSynth output frames.
 
 ## Compilation
 - The CMake configuration of `BM3DCUDA_RTC` links to NVRTC static library by default, which requires CUDA 11.5 or later.

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ The `cpu` version does not require any external libraries but requires AVX2 supp
 {bm3dcuda, bm3dcuda_rtc, bm3dcpu}.BM3D(clip clip[, clip ref=None, float[] sigma=3.0, int[] block_step=8, int[] bm_range=9, int radius=0, int[] ps_num=2, int[] ps_range=4, bint chroma=False, int device_id=0, bool fast=True, int extractor_exp=0])
 ```
 
-Static CUDA also provides execution selection on `BM3Dv2`:
+CUDA and CUDA RTC provide execution selection on `BM3Dv2`:
 
 ```python3
-bm3dcuda.BM3Dv2(clip[, ..., temporal_mode="fused", rolling_chunk=16])
+{bm3dcuda, bm3dcuda_rtc}.BM3Dv2(clip[, ..., temporal_mode="fused", rolling_chunk=16])
 ```
 
 - clip:
@@ -117,17 +117,13 @@ bm3dcuda.BM3Dv2(clip[, ..., temporal_mode="fused", rolling_chunk=16])
 
     Default `0`. (non-determinism)
 
-- temporal_mode, rolling_chunk: (static CUDA `BM3Dv2` only)
+- temporal_mode, rolling_chunk:
 
     `temporal_mode` selects temporal execution for `radius > 0`. `"fused"`
     is the default and retains the existing fused CUDA path. `"legacy"`
     composes public `BM3D` and `VAggregate`. `"rolling"` uses one CUDA
     stream and one resource set to build aligned output chunks; `fast` is
     accepted in this mode for API compatibility but has no effect.
-
-    This experimental rolling mode is implemented only by the static
-    `bm3dcuda` plugin. The `bm3dcuda_rtc` plugin does not accept these two
-    options and continues to use its existing temporal implementation.
 
     `rolling_chunk` sets the rolling chunk size in the range `[1, 64]` and
     defaults to `16`. It may only be supplied with `temporal_mode="rolling"`.
@@ -141,7 +137,7 @@ bm3dcuda.BM3Dv2(clip[, ..., temporal_mode="fused", rolling_chunk=16])
   final GPU aggregation by default. The public `BM3D(radius > 0)` and
   `VAggregate` interfaces retain their existing intermediate-frame behavior.
 
-- Static CUDA rolling chunks are aligned by
+- CUDA rolling chunks are aligned by
   `floor(frame / rolling_chunk) * rolling_chunk`. The filter retains one
   completed chunk of final VapourSynth frames. Requests inside that chunk are
   cache hits; a request outside it recomputes and replaces the aligned chunk,
@@ -154,6 +150,12 @@ bm3dcuda.BM3Dv2(clip[, ..., temporal_mode="fused", rolling_chunk=16])
   normalized output frames to the host. Larger chunks amortize halo work but
   increase GPU accumulators, pinned staging memory, retained frame memory, and
   latency for a random-access miss.
+
+- RTC rolling uses one device resource, one stream, and one Driver API graph.
+  A completed chunk is retained in a frame cache; cache misses stage the
+  source/reference halo, serialize graph execution, and replace the cache.
+  `fast` is accepted for API compatibility but does not change rolling's
+  resource count. Partial final chunks cache only valid output frames.
 
 - `VAggregate(planes=...)` accepts each plane at most once. Plane indices must be non-negative and smaller than the number of planes in `src`.
 
@@ -196,7 +198,7 @@ For the fused CUDA/RTC `BM3Dv2(radius > 0)` path:
 
 `(max((ref ? 2 : 1) * (4 * radius + 1), 2 * (2 * radius + 1)) + 2 * (2 * radius + 1)) * (chroma ? 3 : 1) * (fast ? 4 : 1) * size_of_a_single_frame`
 
-For the rolling static CUDA `BM3Dv2(radius > 0)` path, one stream holds a
+For the rolling CUDA `BM3Dv2(radius > 0)` path, one stream holds a
 source slab, one `2 * radius + 1`-slice scratch result, and
 `rolling_chunk` weighted accumulators. Pinned host memory holds the source slab
 and normalized chunk outputs. The filter additionally retains one chunk of

--- a/cpu_source/source.cpp
+++ b/cpu_source/source.cpp
@@ -1365,8 +1365,8 @@ static void VS_CC BM3DCreate(
 
         if (error) {
             ps_num = (i == 0) ? 2 : d->ps_num[i - 1];
-        } else if (ps_num <= 0) {
-            return set_error("\"ps_num\" must be positive");
+        } else if (ps_num <= 0 || ps_num > 8) {
+            return set_error("\"ps_num\" must be in range [1, 8]");
         }
 
         d->ps_num[i] = ps_num;

--- a/cpu_source/source.cpp
+++ b/cpu_source/source.cpp
@@ -1577,17 +1577,42 @@ static void VS_CC VAggregateCreate(
 
     auto d { std::make_unique<VAggregateData>() };
 
+    const auto set_error = [&](const std::string & error_message) {
+        vsapi->setError(out, ("VAggregate: " + error_message).c_str());
+        if (d->src_node) {
+            vsapi->freeNode(d->src_node);
+        }
+        if (d->node) {
+            vsapi->freeNode(d->node);
+        }
+    };
+
     d->node = vsapi->propGetNode(in, "clip", 0, nullptr);
     auto vi = vsapi->getVideoInfo(d->node);
     d->src_node = vsapi->propGetNode(in, "src", 0, nullptr);
     d->src_vi = vsapi->getVideoInfo(d->src_node);
+
+    const int num_planes = d->src_vi->format->numPlanes;
+    if (num_planes > static_cast<int>(d->process.size())) {
+        return set_error("source clip has too many planes");
+    }
 
     d->radius = (vi->height / d->src_vi->height - 2) / 4;
 
     d->process.fill(false);
     int num_planes_args = vsapi->propNumElements(in, "planes");
     for (int i = 0; i < num_planes_args; ++i) {
-        int plane = vsapi->propGetInt(in, "planes", i, nullptr);
+        int error;
+        int plane = int64ToIntS(vsapi->propGetInt(in, "planes", i, &error));
+        if (error) {
+            return set_error("\"planes\" must contain only integers");
+        }
+        if (plane < 0 || plane >= num_planes) {
+            return set_error("\"planes\" contains an out-of-range plane index");
+        }
+        if (d->process[plane]) {
+            return set_error("\"planes\" contains a duplicate plane index");
+        }
         d->process[plane] = true;
     }
 

--- a/hip_source/source.cpp
+++ b/hip_source/source.cpp
@@ -894,17 +894,42 @@ static void VS_CC VAggregateCreate(
 
     auto d { std::make_unique<VAggregateData>() };
 
+    const auto set_error = [&](const std::string & error_message) {
+        vsapi->setError(out, ("VAggregate: " + error_message).c_str());
+        if (d->src_node) {
+            vsapi->freeNode(d->src_node);
+        }
+        if (d->node) {
+            vsapi->freeNode(d->node);
+        }
+    };
+
     d->node = vsapi->propGetNode(in, "clip", 0, nullptr);
     auto vi = vsapi->getVideoInfo(d->node);
     d->src_node = vsapi->propGetNode(in, "src", 0, nullptr);
     d->src_vi = vsapi->getVideoInfo(d->src_node);
+
+    const int num_planes = d->src_vi->format->numPlanes;
+    if (num_planes > static_cast<int>(d->process.size())) {
+        return set_error("source clip has too many planes");
+    }
 
     d->radius = (vi->height / d->src_vi->height - 2) / 4;
 
     d->process.fill(false);
     int num_planes_args = vsapi->propNumElements(in, "planes");
     for (int i = 0; i < num_planes_args; ++i) {
-        int plane = vsapi->propGetInt(in, "planes", i, nullptr);
+        int error;
+        int plane = int64ToIntS(vsapi->propGetInt(in, "planes", i, &error));
+        if (error) {
+            return set_error("\"planes\" must contain only integers");
+        }
+        if (plane < 0 || plane >= num_planes) {
+            return set_error("\"planes\" contains an out-of-range plane index");
+        }
+        if (d->process[plane]) {
+            return set_error("\"planes\" contains a duplicate plane index");
+        }
         d->process[plane] = true;
     }
 

--- a/rtc_source/kernel.hpp
+++ b/rtc_source/kernel.hpp
@@ -63,7 +63,7 @@ external variables:
     float sigma, int block_step, int bm_range,
     int _radius, int ps_num, int ps_range,
     float sigma_u, float sigma_v,
-    bool temporal, bool chroma, bool final_
+    bool temporal, bool chroma, bool final_, bool fused
     float FLT_MAX, float FLT_EPSILON,
     float extractor,
     __device__ static inline float bm_error(const float *, const float *)
@@ -699,7 +699,10 @@ void bm3d(
     /* shape: [(chroma ? 3 : 1), (2 * radius + 1), 2, height, stride] */
     float * __restrict__ res,
     /* shape: [(final_ ? 2 : 1), (chroma ? 3 : 1), (2 * radius + 1), height, stride] */
-    const float * __restrict__ src
+    const float * __restrict__ src,
+    int source_temporal_width,
+    const int * __restrict__ fused_params,
+    int fused_center
 ) {
 
     __shared__ float buffer[8 * smem_stride];
@@ -724,11 +727,20 @@ void bm3d(
 
     int temporal_stride = height * stride;
     int temporal_width = 2 * radius + 1;
-    int plane_stride = temporal_width * temporal_stride;
-    int clip_stride = (chroma ? 3 : 1) * temporal_width * temporal_stride;
+    int source_valid_width = source_temporal_width;
+    int source_center = radius;
+    int output_z = -1;
+    if constexpr (fused) {
+        source_valid_width = fused_params[0];
+        source_center = fused_params[1 + 2 * fused_center];
+        output_z = fused_params[2 + 2 * fused_center];
+    }
+    int source_plane_stride = (fused ? source_temporal_width : temporal_width) * temporal_stride;
+    int result_plane_stride = (fused ? 1 : temporal_width) * temporal_stride;
+    int clip_stride = (chroma ? 3 : 1) * source_plane_stride;
 
     float current_patch[8];
-    const float * const srcpc = &src[radius * temporal_stride + sub_lane_id];
+    const float * const srcpc = &src[source_center * temporal_stride + sub_lane_id];
 
     {
         const float * srcp = &srcpc[y * stride + x];
@@ -831,7 +843,13 @@ void bm3d(
                 int frame_index8_x = 0;
                 int frame_index8_y = 0;
 
-                const float * temporal_srcpc = &src[temporal_index * temporal_stride + sub_lane_id];
+                int source_index = temporal_index;
+                if constexpr (fused) {
+                    source_index = min(max(
+                        source_center - radius + temporal_index, 0),
+                        source_valid_width - 1);
+                }
+                const float * temporal_srcpc = &src[source_index * temporal_stride + sub_lane_id];
 
                 for (int i = 0; i < ps_num; ++i) {
                     int xx = __shfl_sync(0xFFFFFFFF, last_index8_x, i, 8);
@@ -970,8 +988,8 @@ void bm3d(
 
         if constexpr (chroma) {
             if (sigma < FLT_EPSILON) {
-                src += plane_stride;
-                res += plane_stride * 2;
+                src += source_plane_stride;
+                res += result_plane_stride * 2;
                 continue;
             }
         }
@@ -985,7 +1003,13 @@ void bm3d(
                 const float * refp;
                 if constexpr (temporal) {
                     int tmp_z = __shfl_sync(0xFFFFFFFF, index8_z, i, 8);
-                    refp = &src[tmp_z * temporal_stride + tmp_y * stride + tmp_x + sub_lane_id];
+                    int source_index = tmp_z;
+                    if constexpr (fused) {
+                        source_index = min(max(
+                            source_center - radius + tmp_z, 0),
+                            source_valid_width - 1);
+                    }
+                    refp = &src[source_index * temporal_stride + tmp_y * stride + tmp_x + sub_lane_id];
                 } else {
                     refp = &src[tmp_y * stride + tmp_x + sub_lane_id];
                 }
@@ -1007,7 +1031,13 @@ void bm3d(
                 const float * srcp;
                 if constexpr (temporal) {
                     int tmp_z = __shfl_sync(0xFFFFFFFF, index8_z, i, 8);
-                    srcp = &src[tmp_z * temporal_stride + tmp_y * stride + tmp_x + sub_lane_id];
+                    int source_index = tmp_z;
+                    if constexpr (fused) {
+                        source_index = min(max(
+                            source_center - radius + tmp_z, 0),
+                            source_valid_width - 1);
+                    }
+                    srcp = &src[source_index * temporal_stride + tmp_y * stride + tmp_x + sub_lane_id];
                 } else {
                     srcp = &src[tmp_y * stride + tmp_x + sub_lane_id];
                 }
@@ -1031,6 +1061,12 @@ void bm3d(
             int offset;
             if constexpr (temporal) {
                 int tmp_z = __shfl_sync(0xFFFFFFFF, index8_z, i, 8);
+                if constexpr (fused) {
+                    if (tmp_z != output_z) {
+                        continue;
+                    }
+                    tmp_z = 0;
+                }
                 offset = tmp_z * 2 * temporal_stride + tmp_y * stride + tmp_x;
             } else {
                 offset = tmp_y * stride + tmp_x;
@@ -1058,8 +1094,36 @@ void bm3d(
             }
         }
 
-        src += plane_stride;
-        res += plane_stride * 2;
+        src += source_plane_stride;
+        res += result_plane_stride * 2;
     }
+}
+
+extern "C" __global__ void temporal_normalize(
+    float * __restrict__ res,
+    int normalize_width, int normalize_height, int normalize_stride,
+    int num_planes, int centers
+) {
+    const int x = blockIdx.x * blockDim.x + threadIdx.x;
+    const int y = blockIdx.y;
+    const int plane = blockIdx.z;
+    if (x >= normalize_width || y >= normalize_height || plane >= num_planes) {
+        return;
+    }
+
+    const size_t image_stride = static_cast<size_t>(normalize_height) * normalize_stride;
+    const size_t plane_stride = 2 * image_stride;
+    const size_t center_stride = num_planes * plane_stride;
+    float weighted_sum = 0.0f;
+    float weight = 0.0f;
+    for (int center = 0; center < centers; ++center) {
+        const size_t offset = center * center_stride + plane * plane_stride +
+            y * normalize_stride + x;
+        weighted_sum += res[offset];
+        weight += res[offset + image_stride];
+    }
+
+    res[plane * plane_stride + y * normalize_stride + x] =
+        __fdiv_rn(weighted_sum, weight);
 }
 )""";

--- a/rtc_source/kernel.hpp
+++ b/rtc_source/kernel.hpp
@@ -63,7 +63,7 @@ external variables:
     float sigma, int block_step, int bm_range,
     int _radius, int ps_num, int ps_range,
     float sigma_u, float sigma_v,
-    bool temporal, bool chroma, bool final_, bool fused, bool rolling
+    bool temporal, bool chroma, bool final_, bool rolling
     float FLT_MAX, float FLT_EPSILON,
     float extractor,
     __device__ static inline float bm_error(const float *, const float *)
@@ -701,8 +701,8 @@ void bm3d(
     /* shape: [(final_ ? 2 : 1), (chroma ? 3 : 1), (2 * radius + 1), height, stride] */
     const float * __restrict__ src,
     int source_temporal_width,
-    const int * __restrict__ fused_params,
-    int fused_center
+    const int * __restrict__ rolling_params,
+    int center
 ) {
 
     __shared__ float buffer[8 * smem_stride];
@@ -729,17 +729,12 @@ void bm3d(
     int temporal_width = 2 * radius + 1;
     int source_valid_width = source_temporal_width;
     int source_center = radius;
-    int output_z = -1;
-    if constexpr (fused) {
-        source_valid_width = fused_params[0];
-        source_center = fused_params[1 + 2 * fused_center];
-        output_z = fused_params[2 + 2 * fused_center];
-    } else if constexpr (rolling) {
-        source_valid_width = fused_params[0];
-        source_center = fused_params[1 + fused_center];
+    if constexpr (rolling) {
+        source_valid_width = rolling_params[0];
+        source_center = rolling_params[1 + center];
     }
-    int source_plane_stride = ((fused || rolling) ? source_temporal_width : temporal_width) * temporal_stride;
-    int result_plane_stride = (fused ? 1 : temporal_width) * temporal_stride;
+    int source_plane_stride = (rolling ? source_temporal_width : temporal_width) * temporal_stride;
+    int result_plane_stride = temporal_width * temporal_stride;
     int clip_stride = (chroma ? 3 : 1) * source_plane_stride;
 
     float current_patch[8];
@@ -847,7 +842,7 @@ void bm3d(
                 int frame_index8_y = 0;
 
                 int source_index = temporal_index;
-                if constexpr (fused || rolling) {
+                if constexpr (rolling) {
                     source_index = min(max(
                         source_center - radius + temporal_index, 0),
                         source_valid_width - 1);
@@ -1007,7 +1002,7 @@ void bm3d(
                 if constexpr (temporal) {
                     int tmp_z = __shfl_sync(0xFFFFFFFF, index8_z, i, 8);
                     int source_index = tmp_z;
-                    if constexpr (fused || rolling) {
+                    if constexpr (rolling) {
                         source_index = min(max(
                             source_center - radius + tmp_z, 0),
                             source_valid_width - 1);
@@ -1035,7 +1030,7 @@ void bm3d(
                 if constexpr (temporal) {
                     int tmp_z = __shfl_sync(0xFFFFFFFF, index8_z, i, 8);
                     int source_index = tmp_z;
-                    if constexpr (fused || rolling) {
+                    if constexpr (rolling) {
                         source_index = min(max(
                             source_center - radius + tmp_z, 0),
                             source_valid_width - 1);
@@ -1064,12 +1059,6 @@ void bm3d(
             int offset;
             if constexpr (temporal) {
                 int tmp_z = __shfl_sync(0xFFFFFFFF, index8_z, i, 8);
-                if constexpr (fused) {
-                    if (tmp_z != output_z) {
-                        continue;
-                    }
-                    tmp_z = 0;
-                }
                 offset = tmp_z * 2 * temporal_stride + tmp_y * stride + tmp_x;
             } else {
                 offset = tmp_y * stride + tmp_x;
@@ -1100,34 +1089,6 @@ void bm3d(
         src += source_plane_stride;
         res += result_plane_stride * 2;
     }
-}
-
-extern "C" __global__ void temporal_normalize(
-    float * __restrict__ res,
-    int normalize_width, int normalize_height, int normalize_stride,
-    int num_planes, int centers
-) {
-    const int x = blockIdx.x * blockDim.x + threadIdx.x;
-    const int y = blockIdx.y;
-    const int plane = blockIdx.z;
-    if (x >= normalize_width || y >= normalize_height || plane >= num_planes) {
-        return;
-    }
-
-    const size_t image_stride = static_cast<size_t>(normalize_height) * normalize_stride;
-    const size_t plane_stride = 2 * image_stride;
-    const size_t center_stride = num_planes * plane_stride;
-    float weighted_sum = 0.0f;
-    float weight = 0.0f;
-    for (int center = 0; center < centers; ++center) {
-        const size_t offset = center * center_stride + plane * plane_stride +
-            y * normalize_stride + x;
-        weighted_sum += res[offset];
-        weight += res[offset + image_stride];
-    }
-
-    res[plane * plane_stride + y * normalize_stride + x] =
-        __fdiv_rn(weighted_sum, weight);
 }
 
 extern "C" __global__ void rolling_scatter(

--- a/rtc_source/kernel.hpp
+++ b/rtc_source/kernel.hpp
@@ -63,7 +63,7 @@ external variables:
     float sigma, int block_step, int bm_range,
     int _radius, int ps_num, int ps_range,
     float sigma_u, float sigma_v,
-    bool temporal, bool chroma, bool final_, bool fused
+    bool temporal, bool chroma, bool final_, bool fused, bool rolling
     float FLT_MAX, float FLT_EPSILON,
     float extractor,
     __device__ static inline float bm_error(const float *, const float *)
@@ -734,8 +734,11 @@ void bm3d(
         source_valid_width = fused_params[0];
         source_center = fused_params[1 + 2 * fused_center];
         output_z = fused_params[2 + 2 * fused_center];
+    } else if constexpr (rolling) {
+        source_valid_width = fused_params[0];
+        source_center = fused_params[1 + fused_center];
     }
-    int source_plane_stride = (fused ? source_temporal_width : temporal_width) * temporal_stride;
+    int source_plane_stride = ((fused || rolling) ? source_temporal_width : temporal_width) * temporal_stride;
     int result_plane_stride = (fused ? 1 : temporal_width) * temporal_stride;
     int clip_stride = (chroma ? 3 : 1) * source_plane_stride;
 
@@ -844,7 +847,7 @@ void bm3d(
                 int frame_index8_y = 0;
 
                 int source_index = temporal_index;
-                if constexpr (fused) {
+                if constexpr (fused || rolling) {
                     source_index = min(max(
                         source_center - radius + temporal_index, 0),
                         source_valid_width - 1);
@@ -1004,7 +1007,7 @@ void bm3d(
                 if constexpr (temporal) {
                     int tmp_z = __shfl_sync(0xFFFFFFFF, index8_z, i, 8);
                     int source_index = tmp_z;
-                    if constexpr (fused) {
+                    if constexpr (fused || rolling) {
                         source_index = min(max(
                             source_center - radius + tmp_z, 0),
                             source_valid_width - 1);
@@ -1032,7 +1035,7 @@ void bm3d(
                 if constexpr (temporal) {
                     int tmp_z = __shfl_sync(0xFFFFFFFF, index8_z, i, 8);
                     int source_index = tmp_z;
-                    if constexpr (fused) {
+                    if constexpr (fused || rolling) {
                         source_index = min(max(
                             source_center - radius + tmp_z, 0),
                             source_valid_width - 1);
@@ -1125,5 +1128,51 @@ extern "C" __global__ void temporal_normalize(
 
     res[plane * plane_stride + y * normalize_stride + x] =
         __fdiv_rn(weighted_sum, weight);
+}
+
+extern "C" __global__ void rolling_scatter(
+    float * __restrict__ accum,
+    const float * __restrict__ scratch,
+    const int * __restrict__ params,
+    int width, int height, int stride,
+    int num_planes, int radius, int chunk_size, int center
+) {
+    const int x = blockIdx.x * blockDim.x + threadIdx.x;
+    const int y = blockIdx.y;
+    const int plane = blockIdx.z;
+    if (x >= width || y >= height || plane >= num_planes) return;
+
+    const int temporal_width = 2 * radius + 1;
+    const int source_center = params[1 + center];
+    const int first_output = max(0, center - 2 * radius);
+    const int last_output = min(chunk_size - 1, center);
+    const size_t image_stride = static_cast<size_t>(height) * stride;
+    for (int output = first_output; output <= last_output; ++output) {
+        const int slice = min(max(output + 3 * radius - source_center, 0), temporal_width - 1);
+        const size_t scratch_offset =
+            (static_cast<size_t>(plane) * temporal_width + slice) * 2 * image_stride +
+            static_cast<size_t>(y) * stride + x;
+        const size_t accum_offset =
+            (static_cast<size_t>(output) * num_planes + plane) * 2 * image_stride +
+            static_cast<size_t>(y) * stride + x;
+        accum[accum_offset] += scratch[scratch_offset];
+        accum[accum_offset + image_stride] += scratch[scratch_offset + image_stride];
+    }
+}
+
+extern "C" __global__ void rolling_normalize(
+    float * __restrict__ accum,
+    int width, int height, int stride,
+    int num_planes, int outputs
+) {
+    const int x = blockIdx.x * blockDim.x + threadIdx.x;
+    const int y = blockIdx.y;
+    const int output_plane = blockIdx.z;
+    if (x >= width || y >= height || output_plane >= outputs * num_planes) return;
+
+    const size_t image_stride = static_cast<size_t>(height) * stride;
+    const size_t offset = static_cast<size_t>(output_plane) * 2 * image_stride +
+        static_cast<size_t>(y) * stride + x;
+    accum[offset] = __fdiv_rn(accum[offset], accum[offset + image_stride]);
 }
 )""";

--- a/rtc_source/source.cpp
+++ b/rtc_source/source.cpp
@@ -25,8 +25,10 @@
 #include <cmath>
 #include <concepts>
 #include <cstdint>
+#include <deque>
 #include <ios>
 #include <limits>
+#include <list>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
@@ -174,14 +176,12 @@ struct BM3DData {
     bool chroma;
     bool process[3]; // sigma != 0
     bool final_;
-    bool fused;
     std::string bm_error_s[3];
     std::string transform_2d_s[3];
     std::string transform_1d_s[3];
     bool zero_init;
 
     int d_pitch;
-    size_t params_offset;
 
     CUdevice device;
     CUcontext context; // use primary context
@@ -196,13 +196,13 @@ static std::variant<CUmodule, std::string> compile(
     float sigma, int block_step, int bm_range,
     int radius, int ps_num, int ps_range,
     bool chroma, float sigma_u, float sigma_v,
-    bool final_, bool fused, bool rolling,
+    bool final_, bool rolling,
     const std::string & bm_error_s,
     const std::string & transform_2d_s,
     const std::string & transform_1d_s,
     float extractor,
     CUdevice device
-) noexcept {
+) {
 
     const auto set_error = [](const std::string & error_message) {
         return error_message;
@@ -229,7 +229,6 @@ static std::variant<CUmodule, std::string> compile(
         << "__device__ static const bool temporal = " << (radius > 0) << ";\n"
         << "__device__ static const bool chroma = " << chroma << ";\n"
         << "__device__ static const bool final_ = " << final_ << ";\n"
-        << "__device__ static const bool fused = " << fused << ";\n"
         << "__device__ static const bool rolling = " << rolling << ";\n"
         << "__device__ static const float extractor = " << extractor << ";\n"
         << "__device__ static const float FLT_MAX = "
@@ -363,12 +362,12 @@ static std::variant<CUgraphExec, std::string> get_graphexec(
     {
         CUgraphNode dependencies[] { n_HtoD, n_memset };
         int source_temporal_width = temporal_width;
-        CUdeviceptr fused_params {};
-        int fused_center = 0;
+        CUdeviceptr rolling_params {};
+        int center = 0;
 
         void * kernel_args[] {
             &d_res, &d_src,
-            &source_temporal_width, &fused_params, &fused_center
+            &source_temporal_width, &rolling_params, &center
         };
 
         CUDA_KERNEL_NODE_PARAMS node_params {
@@ -419,155 +418,6 @@ static std::variant<CUgraphExec, std::string> get_graphexec(
     return graphexec;
 }
 
-static std::variant<CUgraphExec, std::string> get_fused_graphexec(
-    CUdeviceptr d_res, CUdeviceptr d_src, float * h_res,
-    CUdeviceptr d_params, int * h_params,
-    int width, int height, int stride,
-    int block_step, int radius, bool chroma, bool final_,
-    CUcontext context, CUfunction function, CUfunction normalize_function
-) noexcept {
-    const auto set_error = [](const std::string & error_message) {
-        return error_message;
-    };
-
-    size_t pitch { stride * sizeof(float) };
-    int centers { 2 * radius + 1 };
-    int source_temporal_width { 4 * radius + 1 };
-    int num_planes { chroma ? 3 : 1 };
-    size_t source_height {
-        static_cast<size_t>(final_ ? 2 : 1) * num_planes *
-            source_temporal_width * height
-    };
-
-    CUgraph graph_;
-    checkError(cuGraphCreate(&graph_, 0));
-    Resource<CUgraph, cuGraphDestroy> graph { graph_ };
-
-    CUgraphNode n_HtoD;
-    CUDA_MEMCPY3D source_copy {
-        .srcMemoryType = CU_MEMORYTYPE_HOST,
-        .srcHost = h_res,
-        .srcPitch = pitch,
-        .dstMemoryType = CU_MEMORYTYPE_DEVICE,
-        .dstDevice = d_src,
-        .dstPitch = pitch,
-        .WidthInBytes = static_cast<size_t>(width) * sizeof(float),
-        .Height = source_height,
-        .Depth = 1,
-    };
-    checkError(cuGraphAddMemcpyNode(
-        &n_HtoD, graph, nullptr, 0, &source_copy, context));
-
-    CUgraphNode n_params;
-    const size_t params_size =
-        (1 + 2 * static_cast<size_t>(centers)) * sizeof(int);
-    CUDA_MEMCPY3D params_copy {
-        .srcMemoryType = CU_MEMORYTYPE_HOST,
-        .srcHost = h_params,
-        .srcPitch = params_size,
-        .dstMemoryType = CU_MEMORYTYPE_DEVICE,
-        .dstDevice = d_params,
-        .dstPitch = params_size,
-        .WidthInBytes = params_size,
-        .Height = 1,
-        .Depth = 1,
-    };
-    checkError(cuGraphAddMemcpyNode(
-        &n_params, graph, nullptr, 0, &params_copy, context));
-
-    CUgraphNode n_memset;
-    CUDA_MEMSET_NODE_PARAMS memset_params {
-        .dst = d_res,
-        .pitch = pitch,
-        .value = 0,
-        .elementSize = 4,
-        .width = static_cast<size_t>(width),
-        .height = static_cast<size_t>(centers) * num_planes * 2 * height,
-    };
-    checkError(cuGraphAddMemsetNode(
-        &n_memset, graph, nullptr, 0, &memset_params, context));
-
-    std::vector<CUgraphNode> center_nodes(centers);
-    const size_t center_stride = static_cast<size_t>(num_planes) * 2 * height * pitch;
-    for (int center = 0; center < centers; ++center) {
-        CUgraphNode dependencies[] { n_HtoD, n_params, n_memset };
-        CUdeviceptr center_res = d_res + center * center_stride;
-        int fused_center = center;
-        void * kernel_args[] {
-            &center_res, &d_src,
-            &source_temporal_width, &d_params, &fused_center
-        };
-
-        CUDA_KERNEL_NODE_PARAMS node_params {
-            .func = function,
-            .gridDimX = static_cast<unsigned int>((width + (4 * block_step - 1)) / (4 * block_step)),
-            .gridDimY = static_cast<unsigned int>((height + (block_step - 1)) / block_step),
-            .gridDimZ = 1,
-            .blockDimX = 32,
-            .blockDimY = 1,
-            .blockDimZ = 1,
-            .sharedMemBytes = 0,
-            .kernelParams = kernel_args,
-        };
-        checkError(cuGraphAddKernelNode(
-            &center_nodes[center], graph,
-            dependencies, std::size(dependencies), &node_params));
-    }
-
-    CUgraphNode n_normalize;
-    {
-        int normalize_width = width;
-        int normalize_height = height;
-        int normalize_stride = stride;
-        void * kernel_args[] {
-            &d_res, &normalize_width, &normalize_height, &normalize_stride,
-            &num_planes, &centers
-        };
-        CUDA_KERNEL_NODE_PARAMS node_params {
-            .func = normalize_function,
-            .gridDimX = static_cast<unsigned int>((width + 255) / 256),
-            .gridDimY = static_cast<unsigned int>(height),
-            .gridDimZ = static_cast<unsigned int>(num_planes),
-            .blockDimX = 256,
-            .blockDimY = 1,
-            .blockDimZ = 1,
-            .sharedMemBytes = 0,
-            .kernelParams = kernel_args,
-        };
-        checkError(cuGraphAddKernelNode(
-            &n_normalize, graph,
-            center_nodes.data(), center_nodes.size(), &node_params));
-    }
-
-    CUgraphNode dependencies[] { n_normalize };
-    for (int plane = 0; plane < num_planes; ++plane) {
-        const size_t plane_offset = static_cast<size_t>(plane) * 2 * height * pitch;
-        CUDA_MEMCPY3D copy_params {
-            .srcMemoryType = CU_MEMORYTYPE_DEVICE,
-            .srcDevice = d_res + plane_offset,
-            .srcPitch = pitch,
-            .dstMemoryType = CU_MEMORYTYPE_HOST,
-            .dstHost = reinterpret_cast<char *>(h_res) + plane_offset,
-            .dstPitch = pitch,
-            .WidthInBytes = static_cast<size_t>(width) * sizeof(float),
-            .Height = static_cast<size_t>(height),
-            .Depth = 1,
-        };
-        CUgraphNode n_DtoH;
-        checkError(cuGraphAddMemcpyNode(
-            &n_DtoH, graph,
-            dependencies, std::size(dependencies), &copy_params, context));
-    }
-
-    CUgraphExec graphexec;
-#if CUDA_VERSION >= 12000
-    checkError(cuGraphInstantiate(&graphexec, graph, 0));
-#else
-    checkError(cuGraphInstantiate(&graphexec, graph, nullptr, nullptr, 0));
-#endif
-    return graphexec;
-}
-
 struct RollingGroup {
     int first_plane;
     int planes;
@@ -595,7 +445,7 @@ static std::variant<CUgraphExec, std::string> get_rolling_graphexec(
     int process_mask, int video_planes, int subsampling_w, int subsampling_h,
     bool chroma, bool final_, float extractor, CUcontext context,
     const std::vector<RollingGroup> & groups
-) noexcept {
+) {
     const auto set_error = [](const std::string & error_message) {
         return error_message;
     };
@@ -818,7 +668,7 @@ static void VS_CC BM3DInit(
 
     BM3DData * d = static_cast<BM3DData *>(*instanceData);
 
-    if (d->radius && !d->fused) {
+    if (d->radius) {
         VSVideoInfo vi = *d->vi;
         vi.height *= 2 * (2 * d->radius + 1);
         vsapi->setVideoInfo(&vi, 1, node);
@@ -835,7 +685,7 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
     auto d = static_cast<BM3DData *>(*instanceData);
 
     if (activationReason == arInitial) {
-        int64_t request_radius = d->fused ? 2LL * d->radius : d->radius;
+        int64_t request_radius = d->radius;
         int start_frame = static_cast<int>(
             std::max<int64_t>(static_cast<int64_t>(n) - request_radius, 0));
         int end_frame = static_cast<int>(std::min<int64_t>(
@@ -853,13 +703,7 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
         int radius = d->radius;
         int temporal_width = 2 * radius + 1;
         bool final_ = d->final_;
-        bool fused = d->fused;
-        int64_t request_radius = fused ? 2LL * radius : radius;
-        int start_frame = static_cast<int>(
-            std::max<int64_t>(static_cast<int64_t>(n) - request_radius, 0));
-        int end_frame = static_cast<int>(std::min<int64_t>(
-            static_cast<int64_t>(n) + request_radius, d->vi->numFrames - 1));
-        int input_width = fused ? end_frame - start_frame + 1 : temporal_width;
+        int input_width = temporal_width;
         int num_input_frames = input_width * (final_ ? 2 : 1); // including ref
 
         using freeFrame_t = decltype(vsapi->freeFrame);
@@ -870,8 +714,7 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
 
             if (final_) {
                 for (int i = 0; i < input_width; ++i) {
-                    int clamped_n = fused ? start_frame + i :
-                        std::clamp(n - radius + i, 0, d->vi->numFrames - 1);
+                    int clamped_n = std::clamp(n - radius + i, 0, d->vi->numFrames - 1);
                     temp.emplace_back(
                         vsapi->getFrameFilter(clamped_n, d->ref_node, frameCtx),
                         vsapi->freeFrame
@@ -880,8 +723,7 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
             }
 
             for (int i = 0; i < input_width; ++i) {
-                int clamped_n = fused ? start_frame + i :
-                    std::clamp(n - radius + i, 0, d->vi->numFrames - 1);
+                int clamped_n = std::clamp(n - radius + i, 0, d->vi->numFrames - 1);
                 temp.emplace_back(
                     vsapi->getFrameFilter(clamped_n, d->node, frameCtx),
                     vsapi->freeFrame
@@ -891,11 +733,11 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
             return temp;
         }();
 
-        int center_index = fused ? n - start_frame : radius;
+        int center_index = radius;
         const VSFrameRef * src = srcs[center_index + (final_ ? input_width : 0)].get();
 
         std::unique_ptr<VSFrameRef, const freeFrame_t &> dst { nullptr, vsapi->freeFrame };
-        if (radius && !fused) {
+        if (radius) {
             dst.reset(
                 vsapi->newVideoFrame(
                     d->vi->format, d->vi->width,
@@ -973,22 +815,6 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
                         }
                         h_src += d_stride * height;
                     }
-                    if (fused) {
-                        h_src += d_stride * height * (4 * radius + 1 - input_width);
-                    }
-                }
-            }
-
-            if (fused) {
-                int * params = reinterpret_cast<int *>(
-                    reinterpret_cast<char *>(h_res) + d->params_offset);
-                params[0] = input_width;
-                for (int center = 0; center < temporal_width; ++center) {
-                    int center_frame = static_cast<int>(std::clamp<int64_t>(
-                        static_cast<int64_t>(n) - radius + center,
-                        0, d->vi->numFrames - 1));
-                    params[1 + 2 * center] = center_frame - start_frame;
-                    params[2 + 2 * center] = n - center_frame + radius;
                 }
             }
 
@@ -999,25 +825,23 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
             float * h_dst = h_res;
             for (int plane = 0; plane < std::ssize(d->process); ++plane) {
                 if (!d->process[plane]) {
-                    h_dst += d_stride * height * 2 * (fused ? 1 : temporal_width);
+                    h_dst += d_stride * height * 2 * temporal_width;
                     continue;
                 }
 
                 float * dstp = reinterpret_cast<float *>(
                     vsapi->getWritePtr(dst.get(), plane));
 
-                if (radius && !fused) {
+                if (radius) {
                     vs_bitblt(
                         dstp, s_pitch, h_dst, d_pitch,
                         width_bytes, height * 2 * temporal_width
                     );
-                } else if (fused) {
-                    vs_bitblt(dstp, s_pitch, h_dst, d_pitch, width_bytes, height);
                 } else {
                     Aggregation(dstp, s_stride, h_dst, d_stride, width, height);
                 }
 
-                h_dst += d_stride * height * 2 * (fused ? 1 : temporal_width);
+                h_dst += d_stride * height * 2 * temporal_width;
             }
         } else { // !d->chroma
             for (int plane = 0; plane < d->vi->format->numPlanes; plane++) {
@@ -1041,22 +865,6 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
                         width_bytes, height
                     );
                     h_src += d_stride * height;
-                    if (fused && (i + 1) % input_width == 0) {
-                        h_src += d_stride * height * (4 * radius + 1 - input_width);
-                    }
-                }
-
-                if (fused) {
-                    int * params = reinterpret_cast<int *>(
-                        reinterpret_cast<char *>(h_res) + d->params_offset);
-                    params[0] = input_width;
-                    for (int center = 0; center < temporal_width; ++center) {
-                        int center_frame = static_cast<int>(std::clamp<int64_t>(
-                            static_cast<int64_t>(n) - radius + center,
-                            0, d->vi->numFrames - 1));
-                        params[1 + 2 * center] = center_frame - start_frame;
-                        params[2 + 2 * center] = n - center_frame + radius;
-                    }
                 }
 
                 checkError(cuGraphLaunch(graphexec, stream));
@@ -1066,13 +874,11 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
                 float * dstp = reinterpret_cast<float *>(
                     vsapi->getWritePtr(dst.get(), plane));
 
-                if (radius && !fused) {
+                if (radius) {
                     vs_bitblt(
                         dstp, s_pitch, h_res, d_pitch,
                         width_bytes, height * 2 * temporal_width
                     );
-                } else if (fused) {
-                    vs_bitblt(dstp, s_pitch, h_res, d_pitch, width_bytes, height);
                 } else {
                     Aggregation(dstp, s_stride, h_res, d_stride, width, height);
                 }
@@ -1086,7 +892,7 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
         d->resources_lock.unlock();
         d->semaphore.release();
 
-        if (radius && !fused) {
+        if (radius) {
             VSMap * dst_prop { vsapi->getFramePropsRW(dst.get()) };
 
             vsapi->propSetInt(dst_prop, "BM3D_V_radius", d->radius, paReplace);
@@ -1123,7 +929,7 @@ static void VS_CC BM3DFree(
 
 static void BM3DCreateImpl(
     const VSMap *in, VSMap *out, void *userData,
-    VSCore *core, const VSAPI *vsapi, bool fused
+    VSCore *core, const VSAPI *vsapi
 ) noexcept {
 
     auto d { std::make_unique<BM3DData>() };
@@ -1166,7 +972,6 @@ static void BM3DCreateImpl(
         final_ = true;
     }
     d->final_ = final_;
-    d->fused = fused;
 
     float sigma[3];
     for (int i = 0; i < std::ssize(sigma); ++i) {
@@ -1223,9 +1028,6 @@ static void BM3DCreateImpl(
     }();
     if (radius < 0) {
         return set_error("\"radius\" must be non-negative");
-    }
-    if (fused && radius > (std::numeric_limits<int>::max() - 1) / 4) {
-        return set_error("\"radius\" is too large for fused temporal processing");
     }
     d->radius = radius;
 
@@ -1356,31 +1158,12 @@ static void BM3DCreateImpl(
     };
     const int num_planes { chroma ? 3 : 1 };
     const int temporal_width = 2 * radius + 1;
-    const int source_temporal_width = fused ? 4 * radius + 1 : temporal_width;
-    if (fused) {
-        const size_t min_temporal_stride =
-            static_cast<size_t>(max_width) * max_height;
-        const size_t max_kernel_offset = std::numeric_limits<int>::max();
-        if (
-            min_temporal_stride > max_kernel_offset ||
-            static_cast<size_t>(source_temporal_width) >
-                max_kernel_offset / min_temporal_stride ||
-            static_cast<size_t>(num_planes) > max_kernel_offset /
-                (min_temporal_stride * source_temporal_width)) {
-            return set_error("\"radius\" is too large for the clip dimensions");
-        }
-    }
+    const int source_temporal_width = temporal_width;
     const size_t source_rows = static_cast<size_t>(final_ ? 2 : 1) *
         static_cast<size_t>(num_planes) * source_temporal_width * max_height;
     const size_t result_rows = static_cast<size_t>(num_planes) *
         temporal_width * 2 * max_height;
     const size_t buffer_rows = std::max(source_rows, result_rows);
-    const size_t params_size = fused ?
-        (1 + 2 * static_cast<size_t>(temporal_width)) * sizeof(int) : 0;
-    const size_t min_pitch = static_cast<size_t>(max_width) * sizeof(float);
-    const size_t params_rows = fused ?
-        (params_size + min_pitch - 1) / min_pitch : 0;
-
     d->semaphore.current.store(num_copy_engines - 1, std::memory_order::relaxed);
 
     // GPU related
@@ -1410,13 +1193,12 @@ static void BM3DCreateImpl(
         size_t d_pitch;
         int d_stride;
         CUfunction functions[3];
-        CUfunction normalize_functions[3];
         for (int i = 0; i < num_copy_engines; ++i) {
             Resource<CUdeviceptr, cuMemFree> d_src {};
             if (i == 0) {
                 checkError(cuMemAllocPitch(
                     &d_src.data, &d_pitch, max_width * sizeof(float),
-                    fused ? buffer_rows + params_rows : source_rows, 4
+                    source_rows, 4
                 ));
                 if (d_pitch > static_cast<size_t>(std::numeric_limits<int>::max())) {
                     d_src = CUdeviceptr {};
@@ -1425,27 +1207,9 @@ static void BM3DCreateImpl(
                     return set_error("device pitch exceeds the supported range");
                 }
                 d_stride = static_cast<int>(d_pitch / sizeof(float));
-                if (fused) {
-                    const size_t temporal_stride =
-                        static_cast<size_t>(max_height) * d_stride;
-                    const size_t max_kernel_offset = std::numeric_limits<int>::max();
-                    if (
-                        temporal_stride > max_kernel_offset ||
-                        static_cast<size_t>(source_temporal_width) >
-                            max_kernel_offset / temporal_stride ||
-                        static_cast<size_t>(num_planes) > max_kernel_offset /
-                            (temporal_stride * source_temporal_width)) {
-                        d_src = CUdeviceptr {};
-                        cuCtxPopCurrent(nullptr);
-                        cuDevicePrimaryCtxRelease(d->device);
-                        return set_error("\"radius\" is too large for the device pitch");
-                    }
-                }
                 d->d_pitch = static_cast<int>(d_pitch);
-                d->params_offset = buffer_rows * d_pitch;
             } else {
-                checkError(cuMemAlloc(&d_src.data,
-                    fused ? buffer_rows * d_pitch + params_size : source_rows * d_pitch));
+                checkError(cuMemAlloc(&d_src.data, source_rows * d_pitch));
             }
 
             Resource<CUdeviceptr, cuMemFree> d_res {};
@@ -1453,7 +1217,7 @@ static void BM3DCreateImpl(
 
             Resource<float *, cuMemFreeHost> h_res {};
             checkError(cuMemAllocHost(reinterpret_cast<void **>(&h_res.data),
-                buffer_rows * d_pitch + params_size));
+                buffer_rows * d_pitch));
 
             Resource<CUstream, cuStreamDestroy> stream {};
             checkError(cuStreamCreate(&stream.data, CU_STREAM_NON_BLOCKING));
@@ -1466,7 +1230,7 @@ static void BM3DCreateImpl(
                         sigma[0], block_step[0], bm_range[0],
                         radius, ps_num[0], ps_range[0],
                         true, sigma[1], sigma[2],
-                        final_, fused, false,
+                        final_, false,
                         d->bm_error_s[0],
                         d->transform_2d_s[0], d->transform_1d_s[0],
                         extractor,
@@ -1480,20 +1244,9 @@ static void BM3DCreateImpl(
                     }
 
                     checkError(cuModuleGetFunction(&functions[0], d->modules[0], "bm3d"));
-                    if (fused) {
-                        checkError(cuModuleGetFunction(
-                            &normalize_functions[0], d->modules[0], "temporal_normalize"));
-                    }
                 }
 
-                const auto result = fused ? get_fused_graphexec(
-                    d_res, d_src, h_res,
-                    d_src.data + d->params_offset,
-                    reinterpret_cast<int *>(reinterpret_cast<char *>(h_res.data) + d->params_offset),
-                    width, height, d_stride,
-                    block_step[0], radius, true, final_, d->context,
-                    functions[0], normalize_functions[0]
-                ) : get_graphexec(
+                const auto result = get_graphexec(
                     d_res, d_src, h_res,
                     width, height, d_stride,
                     block_step[0], radius, true, final_, d->context,
@@ -1518,7 +1271,7 @@ static void BM3DCreateImpl(
                                 plane_width, plane_height, d_stride,
                                 sigma[plane], block_step[plane], bm_range[plane],
                                 radius, ps_num[plane], ps_range[plane],
-                                false, 0.0f, 0.0f, final_, fused, false,
+                                false, 0.0f, 0.0f, final_, false,
                                 d->bm_error_s[plane],
                                 d->transform_2d_s[plane], d->transform_1d_s[plane],
                                 extractor,
@@ -1533,21 +1286,9 @@ static void BM3DCreateImpl(
 
                             checkError(cuModuleGetFunction(
                                 &functions[plane], d->modules[plane], "bm3d"));
-                            if (fused) {
-                                checkError(cuModuleGetFunction(
-                                    &normalize_functions[plane], d->modules[plane],
-                                    "temporal_normalize"));
-                            }
                         }
 
-                        const auto result = fused ? get_fused_graphexec(
-                            d_res, d_src, h_res,
-                            d_src.data + d->params_offset,
-                            reinterpret_cast<int *>(reinterpret_cast<char *>(h_res.data) + d->params_offset),
-                            plane_width, plane_height, d_stride,
-                            block_step[plane], radius, false, final_, d->context,
-                            functions[plane], normalize_functions[plane]
-                        ) : get_graphexec(
+                        const auto result = get_graphexec(
                             d_res, d_src, h_res,
                             plane_width, plane_height, d_stride,
                             block_step[plane], radius, false, final_, d->context,
@@ -1575,7 +1316,7 @@ static void BM3DCreateImpl(
     }
 
     vsapi->createFilter(
-        in, out, fused ? "BM3Dv2" : "BM3D",
+        in, out, "BM3D",
         BM3DInit, BM3DGetFrame, BM3DFree,
         fmParallel, 0, d.release(), core
     );
@@ -1585,7 +1326,7 @@ static void VS_CC BM3DCreate(
     const VSMap *in, VSMap *out, void *userData,
     VSCore *core, const VSAPI *vsapi
 ) noexcept {
-    BM3DCreateImpl(in, out, userData, core, vsapi, false);
+    BM3DCreateImpl(in, out, userData, core, vsapi);
 }
 
 struct RollingResource {
@@ -1604,8 +1345,12 @@ struct RollingData {
     VSNodeRef * node {};
     VSNodeRef * ref_node {};
     const VSVideoInfo * vi {};
+    const VSAPI * vsapi {};
     int radius {};
     int chunk_size {};
+    std::atomic<int> cache_chunks { 1 };
+    int cache_limit { 1 };
+    bool cache_adaptive {};
     int d_pitch {};
     CUdevice device {};
     CUcontext context {};
@@ -1623,11 +1368,58 @@ struct RollingData {
     RollingResource resource;
     std::mutex resource_lock;
     mutable std::shared_mutex cache_lock;
-    int cached_start { -1 };
-    std::vector<const VSFrameRef *> cached_frames;
-};
+    struct CacheChunk {
+        int start {};
+        std::vector<const VSFrameRef *> frames;
 
-struct RollingRequest { int chunk_start; };
+        const VSAPI * vsapi {};
+
+        CacheChunk() noexcept = default;
+
+        CacheChunk(
+            int start_, std::vector<const VSFrameRef *> && frames_,
+            const VSAPI * vsapi_
+        ) noexcept :
+            start { start_ }, frames { std::move(frames_) }, vsapi { vsapi_ }
+        {}
+
+        CacheChunk(const CacheChunk &) = delete;
+        CacheChunk & operator=(const CacheChunk &) = delete;
+
+        CacheChunk(CacheChunk && other) noexcept :
+            start { other.start }, frames { std::move(other.frames) },
+            vsapi { std::exchange(other.vsapi, nullptr) }
+        {}
+
+        CacheChunk & operator=(CacheChunk && other) noexcept {
+            if (this != &other) {
+                release();
+                start = other.start;
+                frames = std::move(other.frames);
+                vsapi = std::exchange(other.vsapi, nullptr);
+            }
+            return *this;
+        }
+
+        ~CacheChunk() noexcept { release(); }
+
+    private:
+        void release() noexcept {
+            if (!vsapi) return;
+            for (const VSFrameRef * frame : frames) {
+                vsapi->freeFrame(frame);
+            }
+        }
+    };
+    std::list<CacheChunk> cached_chunks;
+    std::deque<int> evicted_chunks;
+    int cache_reuse_events {};
+
+    ~RollingData() noexcept {
+        if (node) vsapi->freeNode(node);
+        if (ref_node) vsapi->freeNode(ref_node);
+    }
+};
 
 static bool checked_mul(size_t lhs, size_t rhs, size_t & result) noexcept {
     if (lhs && rhs > std::numeric_limits<size_t>::max() / lhs) return false;
@@ -1650,32 +1442,66 @@ static void VS_CC RollingInit(
 }
 
 static const VSFrameRef * rolling_cache_get(
-    const RollingData * d, int n, const VSAPI *vsapi
-) noexcept {
-    std::shared_lock lock { d->cache_lock };
-    const int offset = n - d->cached_start;
-    if (offset < 0 || offset >= std::ssize(d->cached_frames)) return nullptr;
-    return vsapi->cloneFrameRef(d->cached_frames[offset]);
+    RollingData * d, int n, const VSAPI *vsapi
+) {
+    if (d->cache_chunks.load(std::memory_order_relaxed) == 1) {
+        std::shared_lock lock { d->cache_lock };
+        if (d->cached_chunks.empty()) return nullptr;
+        const auto & cache = d->cached_chunks.front();
+        const int offset = n - cache.start;
+        if (offset < 0 || offset >= std::ssize(cache.frames)) return nullptr;
+        return vsapi->cloneFrameRef(cache.frames[offset]);
+    }
+
+    std::unique_lock lock { d->cache_lock };
+    for (auto it = d->cached_chunks.begin(); it != d->cached_chunks.end();
+        ++it) {
+        const int offset = n - it->start;
+        if (offset < 0 || offset >= std::ssize(it->frames)) continue;
+        if (std::next(it) != d->cached_chunks.end()) {
+            d->cached_chunks.splice(
+                d->cached_chunks.end(), d->cached_chunks, it);
+            it = std::prev(d->cached_chunks.end());
+        }
+        return vsapi->cloneFrameRef(it->frames[offset]);
+    }
+    return nullptr;
 }
 
-static const VSFrameRef *VS_CC RollingGetFrame(
-    int n, int activationReason, void **instanceData, void **frameData,
+static void rolling_cache_maybe_grow(
+    RollingData * d, int chunk_start
+) {
+    if (!d->cache_adaptive) return;
+
+    std::unique_lock lock { d->cache_lock };
+    if (d->cache_chunks.load(std::memory_order_relaxed) >= d->cache_limit) {
+        return;
+    }
+    const auto evicted = std::find(
+        d->evicted_chunks.begin(), d->evicted_chunks.end(), chunk_start);
+    if (evicted == d->evicted_chunks.end()) return;
+    d->evicted_chunks.erase(evicted);
+    if (++d->cache_reuse_events < 2) return;
+    d->cache_reuse_events = 0;
+    d->cache_chunks.fetch_add(1, std::memory_order_relaxed);
+}
+
+static const VSFrameRef * RollingGetFrameImpl(
+    int n, int activationReason, void **instanceData, void **,
     VSFrameContext *frameCtx, VSCore *core, const VSAPI *vsapi
-) noexcept {
+) {
     auto d = static_cast<RollingData *>(*instanceData);
     if (activationReason == arInitial) {
-        const int chunk_start = n / d->chunk_size * d->chunk_size;
-        *frameData = new RollingRequest { chunk_start };
         if (const VSFrameRef * cached = rolling_cache_get(d, n, vsapi)) {
-            delete static_cast<RollingRequest *>(*frameData);
-            *frameData = nullptr;
             return cached;
         }
+        const int64_t chunk_start =
+            static_cast<int64_t>(n / d->chunk_size) * d->chunk_size;
+        const int64_t clip_last = static_cast<int64_t>(d->vi->numFrames) - 1;
         const int64_t first = std::max<int64_t>(
-            static_cast<int64_t>(chunk_start) - 2LL * d->radius, 0);
+            chunk_start - 2LL * d->radius, 0);
         const int64_t last = std::min<int64_t>(
-            static_cast<int64_t>(chunk_start) + d->chunk_size - 1 + 2LL * d->radius,
-            d->vi->numFrames - 1);
+            chunk_start + d->chunk_size - 1 + 2LL * d->radius, clip_last);
         for (int64_t frame = first; frame <= last; ++frame) {
             vsapi->requestFrameFilter(static_cast<int>(frame), d->node, frameCtx);
             if (d->final_) vsapi->requestFrameFilter(
@@ -1684,19 +1510,18 @@ static const VSFrameRef *VS_CC RollingGetFrame(
         return nullptr;
     }
     if (activationReason == arError) {
-        delete static_cast<RollingRequest *>(*frameData);
-        *frameData = nullptr;
         return nullptr;
     }
     if (activationReason != arAllFramesReady) return nullptr;
 
-    std::unique_ptr<RollingRequest> request {
-        static_cast<RollingRequest *>(*frameData) };
-    *frameData = nullptr;
     if (const VSFrameRef * cached = rolling_cache_get(d, n, vsapi)) return cached;
 
     std::unique_lock resource_guard { d->resource_lock };
     if (const VSFrameRef * cached = rolling_cache_get(d, n, vsapi)) return cached;
+    const int64_t chunk_start_64 =
+        static_cast<int64_t>(n / d->chunk_size) * d->chunk_size;
+    const int chunk_start = static_cast<int>(chunk_start_64);
+    rolling_cache_maybe_grow(d, chunk_start);
     const auto set_error = [&](const std::string & message) {
         vsapi->setFilterError(("BM3Dv2 rolling: " + message).c_str(), frameCtx);
         return static_cast<const VSFrameRef *>(nullptr);
@@ -1709,15 +1534,17 @@ static const VSFrameRef *VS_CC RollingGetFrame(
     struct ContextGuard {
         ~ContextGuard() noexcept { cuCtxPopCurrent(nullptr); }
     } context_guard;
-    const int chunk_start = request->chunk_start;
-    const int valid_outputs = std::min(d->chunk_size, d->vi->numFrames - chunk_start);
-    const int logical_first = chunk_start - 2 * d->radius;
+    const int64_t clip_last = static_cast<int64_t>(d->vi->numFrames) - 1;
+    const int valid_outputs = static_cast<int>(std::min<int64_t>(
+        d->chunk_size, static_cast<int64_t>(d->vi->numFrames) - chunk_start_64));
+    const int64_t logical_first = chunk_start_64 - 2LL * d->radius;
     const int logical_source_width = d->chunk_size + 4 * d->radius;
     const int centers = d->chunk_size + 2 * d->radius;
-    const int first_frame = std::max(logical_first, 0);
-    const int last_frame = std::min(
-        chunk_start + d->chunk_size - 1 + 2 * d->radius,
-        d->vi->numFrames - 1);
+    const int first_frame = static_cast<int>(std::max<int64_t>(
+        logical_first, 0));
+    const int last_frame = static_cast<int>(std::min<int64_t>(
+        chunk_start_64 + d->chunk_size - 1 + 2LL * d->radius,
+        clip_last));
     const int unique_frames = last_frame - first_frame + 1;
     using freeFrame_t = decltype(vsapi->freeFrame);
     using FramePtr = std::unique_ptr<const VSFrameRef, const freeFrame_t &>;
@@ -1725,10 +1552,13 @@ static const VSFrameRef *VS_CC RollingGetFrame(
     std::vector<FramePtr> reference_frames;
     source_frames.reserve(unique_frames);
     reference_frames.reserve(d->final_ ? unique_frames : 0);
-    for (int frame = first_frame; frame <= last_frame; ++frame) {
-        source_frames.emplace_back(vsapi->getFrameFilter(frame, d->node, frameCtx), vsapi->freeFrame);
+    for (int64_t frame = first_frame; frame <= last_frame; ++frame) {
+        source_frames.emplace_back(vsapi->getFrameFilter(
+            static_cast<int>(frame), d->node, frameCtx), vsapi->freeFrame);
         if (d->final_) reference_frames.emplace_back(
-            vsapi->getFrameFilter(frame, d->ref_node, frameCtx), vsapi->freeFrame);
+            vsapi->getFrameFilter(
+                static_cast<int>(frame), d->ref_node, frameCtx),
+            vsapi->freeFrame);
     }
 
     RollingResource & resource = d->resource;
@@ -1738,7 +1568,8 @@ static const VSFrameRef *VS_CC RollingGetFrame(
         const int plane_width = vsapi->getFrameWidth(frames.front().get(), plane);
         const int source_pitch = vsapi->getStride(frames.front().get(), plane);
         for (int logical = 0; logical < logical_source_width; ++logical) {
-            const int frame = std::clamp(logical_first + logical, 0, d->vi->numFrames - 1);
+            const int frame = static_cast<int>(std::clamp<int64_t>(
+                logical_first + logical, 0, clip_last));
             const VSFrameRef * source = frames[frame - first_frame].get();
             vs_bitblt(dst, d->d_pitch, vsapi->getReadPtr(source, plane), source_pitch,
                 plane_width * sizeof(float), plane_height);
@@ -1761,8 +1592,10 @@ static const VSFrameRef *VS_CC RollingGetFrame(
     }
     resource.h_params.data[0] = logical_source_width;
     for (int center = 0; center < centers; ++center) {
-        const int frame = std::clamp(chunk_start - d->radius + center, 0, d->vi->numFrames - 1);
-        resource.h_params.data[1 + center] = frame - logical_first;
+        const int64_t frame = std::clamp<int64_t>(
+            chunk_start_64 - d->radius + center, 0, clip_last);
+        resource.h_params.data[1 + center] =
+            static_cast<int>(frame - logical_first);
     }
     checkError(cuGraphLaunch(resource.graphexec, resource.stream));
     checkError(cuStreamSynchronize(resource.stream));
@@ -1770,7 +1603,9 @@ static const VSFrameRef *VS_CC RollingGetFrame(
     std::vector<const VSFrameRef *> new_cache;
     new_cache.reserve(valid_outputs);
     for (int output = 0; output < valid_outputs; ++output) {
-        const VSFrameRef * source = source_frames[chunk_start + output - first_frame].get();
+        const size_t source_index = static_cast<size_t>(
+            chunk_start_64 + output - first_frame);
+        const VSFrameRef * source = source_frames[source_index].get();
         const VSFrameRef * plane_sources[] {
             d->process[0] ? nullptr : source,
             d->process[1] ? nullptr : source,
@@ -1792,24 +1627,57 @@ static const VSFrameRef *VS_CC RollingGetFrame(
         }
         new_cache.push_back(destination);
     }
-    std::vector<const VSFrameRef *> old_cache;
+    RollingData::CacheChunk new_chunk {
+        chunk_start, std::move(new_cache), vsapi
+    };
+    std::list<RollingData::CacheChunk> evicted;
     {
         std::unique_lock lock { d->cache_lock };
-        old_cache = std::move(d->cached_frames);
-        d->cached_frames = std::move(new_cache);
-        d->cached_start = chunk_start;
+        d->cached_chunks.push_back(std::move(new_chunk));
+        while (std::ssize(d->cached_chunks) >
+            d->cache_chunks.load(std::memory_order_relaxed)) {
+            evicted.splice(evicted.end(), d->cached_chunks,
+                d->cached_chunks.begin());
+            if (d->cache_adaptive) {
+                d->evicted_chunks.push_back(evicted.back().start);
+                const size_t history_limit = std::max(
+                    size_t { 8 }, static_cast<size_t>(d->cache_limit) * 2);
+                while (d->evicted_chunks.size() > history_limit) {
+                    d->evicted_chunks.pop_front();
+                }
+            }
+        }
     }
-    for (const VSFrameRef * frame : old_cache) vsapi->freeFrame(frame);
     return rolling_cache_get(d, n, vsapi);
+}
+
+static const VSFrameRef *VS_CC RollingGetFrame(
+    int n, int activationReason, void **instanceData, void **frameData,
+    VSFrameContext *frameCtx, VSCore *core, const VSAPI *vsapi
+) noexcept {
+    try {
+        return RollingGetFrameImpl(
+            n, activationReason, instanceData, frameData,
+            frameCtx, core, vsapi);
+    } catch (const std::bad_alloc &) {
+        vsapi->setFilterError(
+            "BM3Dv2 rolling: memory allocation failed", frameCtx);
+    } catch (const std::exception & error) {
+        vsapi->setFilterError(error.what(), frameCtx);
+    } catch (...) {
+        vsapi->setFilterError("BM3Dv2 rolling: internal error", frameCtx);
+    }
+    return nullptr;
 }
 
 static void VS_CC RollingFree(void *instanceData, VSCore *, const VSAPI *vsapi) noexcept {
     auto d = static_cast<RollingData *>(instanceData);
-    std::vector<const VSFrameRef *> cached;
-    { std::unique_lock lock { d->cache_lock }; cached = std::move(d->cached_frames); }
-    for (const VSFrameRef * frame : cached) vsapi->freeFrame(frame);
-    vsapi->freeNode(d->node);
-    vsapi->freeNode(d->ref_node);
+    std::list<RollingData::CacheChunk> cached;
+    {
+        std::unique_lock lock { d->cache_lock };
+        cached.splice(cached.end(), d->cached_chunks);
+    }
+    cached.clear();
     const CUdevice device = d->device;
     cuCtxPushCurrent(d->context);
     delete d;
@@ -1818,19 +1686,15 @@ static void VS_CC RollingFree(void *instanceData, VSCore *, const VSAPI *vsapi) 
 }
 
 static void RollingCreate(
-    const VSMap *in, VSMap *out, int chunk_size,
+    const VSMap *in, VSMap *out, int chunk_size, int cache_chunks,
+    int cache_limit, bool cache_adaptive,
     VSCore *core, const VSAPI *vsapi
 ) noexcept {
-    auto d = std::make_unique<RollingData>();
+    std::unique_ptr<RollingData> d;
     bool primary_context_retained = false;
     bool context_pushed = false;
-    const auto set_error = [&](const std::string & message) {
-        vsapi->setError(out, ("BM3Dv2 rolling: " + message).c_str());
-        if (d->node) vsapi->freeNode(d->node);
-        if (d->ref_node) vsapi->freeNode(d->ref_node);
-        d->node = nullptr;
-        d->ref_node = nullptr;
-        const CUdevice retained_device = d->device;
+    const auto cleanup = [&]() noexcept {
+        const CUdevice retained_device = d ? d->device : CUdevice {};
         // Resource destructors need the owning CUDA context to be current.
         d.reset();
         if (context_pushed) {
@@ -1841,6 +1705,17 @@ static void RollingCreate(
             cuDevicePrimaryCtxRelease(retained_device);
             primary_context_retained = false;
         }
+    };
+
+    try {
+    d = std::make_unique<RollingData>();
+    d->vsapi = vsapi;
+    d->cache_chunks.store(cache_chunks, std::memory_order_relaxed);
+    d->cache_limit = cache_limit;
+    d->cache_adaptive = cache_adaptive;
+    const auto set_error = [&](const std::string & message) {
+        vsapi->setError(out, ("BM3Dv2 rolling: " + message).c_str());
+        cleanup();
     };
     d->node = vsapi->propGetNode(in, "clip", 0, nullptr);
     d->vi = vsapi->getVideoInfo(d->node);
@@ -2051,7 +1926,7 @@ static void RollingCreate(
             group.sigma, group.block_step, group.bm_range,
             d->radius, group.ps_num, group.ps_range,
             d->chroma, d->chroma ? sigma[1] : 0.0f, d->chroma ? sigma[2] : 0.0f,
-            d->final_, false, true,
+            d->final_, true,
             d->bm_error_s[plane], d->transform_2d_s[plane], d->transform_1d_s[plane],
             extractor, d->device);
         if (std::holds_alternative<std::string>(result)) return set_error(std::get<std::string>(result));
@@ -2075,6 +1950,16 @@ static void RollingCreate(
     primary_context_retained = false;
     vsapi->createFilter(in, out, "BM3Dv2 rolling", RollingInit, RollingGetFrame,
         RollingFree, fmParallelRequests, 0, d.release(), core);
+    } catch (const std::bad_alloc &) {
+        cleanup();
+        vsapi->setError(out, "BM3Dv2 rolling: memory allocation failed");
+    } catch (const std::exception & error) {
+        cleanup();
+        vsapi->setError(out, error.what());
+    } catch (...) {
+        cleanup();
+        vsapi->setError(out, "BM3Dv2 rolling: internal error");
+    }
 }
 
 static VSMap * copy_bm3d_args(const VSMap *in, const VSAPI *vsapi) noexcept {
@@ -2082,7 +1967,9 @@ static VSMap * copy_bm3d_args(const VSMap *in, const VSAPI *vsapi) noexcept {
     for (int key_index = 0; key_index < vsapi->propNumKeys(in); ++key_index) {
         const char *key = vsapi->propGetKey(in, key_index);
         if (std::string_view { key } == "temporal_mode" ||
-            std::string_view { key } == "rolling_chunk") continue;
+            std::string_view { key } == "rolling_chunk" ||
+            std::string_view { key } == "rolling_cache_chunks" ||
+            std::string_view { key } == "rolling_cache_limit") continue;
         const int elements = vsapi->propNumElements(in, key);
         const int type = vsapi->propGetType(in, key);
         for (int index = 0; index < elements; ++index) {
@@ -2326,15 +2213,17 @@ static void VS_CC BM3Dv2Create(
 ) {
 
     int error;
-    std::string temporal_mode { "fused" };
-    if (vsapi->propNumElements(in, "temporal_mode") >= 0) {
+    std::string temporal_mode { "rolling" };
+    const bool temporal_mode_supplied =
+        vsapi->propNumElements(in, "temporal_mode") >= 0;
+    if (temporal_mode_supplied) {
         const char * value = vsapi->propGetData(in, "temporal_mode", 0, &error);
         const int size = vsapi->propGetDataSize(in, "temporal_mode", 0, &error);
         if (error) { vsapi->setError(out, "BM3Dv2: \"temporal_mode\" must be a string"); return; }
         temporal_mode.assign(value, size);
     }
-    if (temporal_mode != "fused" && temporal_mode != "legacy" && temporal_mode != "rolling") {
-        vsapi->setError(out, "BM3Dv2: \"temporal_mode\" must be one of fused, legacy, or rolling");
+    if (temporal_mode != "legacy" && temporal_mode != "rolling") {
+        vsapi->setError(out, "BM3Dv2: \"temporal_mode\" must be one of legacy or rolling");
         return;
     }
     const bool chunk_supplied = vsapi->propNumElements(in, "rolling_chunk") >= 0;
@@ -2342,13 +2231,58 @@ static void VS_CC BM3Dv2Create(
         vsapi->setError(out, "BM3Dv2: \"rolling_chunk\" is valid only when temporal_mode is rolling");
         return;
     }
-    int rolling_chunk = 16;
+    int rolling_chunk = 4;
     if (chunk_supplied) {
         rolling_chunk = int64ToIntS(vsapi->propGetInt(in, "rolling_chunk", 0, &error));
         if (error || rolling_chunk < 1 || rolling_chunk > 64) {
             vsapi->setError(out, "BM3Dv2: \"rolling_chunk\" must be in range [1, 64]");
             return;
         }
+    }
+
+    const bool cache_chunks_supplied =
+        vsapi->propNumElements(in, "rolling_cache_chunks") >= 0;
+    if (cache_chunks_supplied && temporal_mode != "rolling") {
+        vsapi->setError(out,
+            "BM3Dv2: \"rolling_cache_chunks\" is valid only when temporal_mode is rolling");
+        return;
+    }
+    int rolling_cache_chunks = 1;
+    if (cache_chunks_supplied) {
+        rolling_cache_chunks = int64ToIntS(
+            vsapi->propGetInt(in, "rolling_cache_chunks", 0, &error));
+        if (error || rolling_cache_chunks < 1 || rolling_cache_chunks > 64) {
+            vsapi->setError(out,
+                "BM3Dv2: \"rolling_cache_chunks\" must be in range [1, 64]");
+            return;
+        }
+    }
+
+    const bool cache_limit_supplied =
+        vsapi->propNumElements(in, "rolling_cache_limit") >= 0;
+    if (cache_limit_supplied && temporal_mode != "rolling") {
+        vsapi->setError(out,
+            "BM3Dv2: \"rolling_cache_limit\" is valid only when temporal_mode is rolling");
+        return;
+    }
+    int rolling_cache_limit = 16;
+    if (cache_limit_supplied) {
+        rolling_cache_limit = int64ToIntS(
+            vsapi->propGetInt(in, "rolling_cache_limit", 0, &error));
+        if (error || rolling_cache_limit < 1 || rolling_cache_limit > 64) {
+            vsapi->setError(out,
+                "BM3Dv2: \"rolling_cache_limit\" must be in range [1, 64]");
+            return;
+        }
+    }
+    if (rolling_cache_limit < rolling_cache_chunks) {
+        vsapi->setError(out,
+            "BM3Dv2: \"rolling_cache_limit\" must be greater than or equal to \"rolling_cache_chunks\"");
+        return;
+    }
+    const bool cache_adaptive = cache_limit_supplied || !cache_chunks_supplied;
+    if (!cache_adaptive) {
+        rolling_cache_limit = rolling_cache_chunks;
     }
 
     std::array<bool, 3> process;
@@ -2374,7 +2308,7 @@ static void VS_CC BM3Dv2Create(
     error = 0;
     int radius = int64ToIntS(vsapi->propGetInt(in, "radius", 0, &error));
     if (error) radius = 0;
-    if (temporal_mode == "rolling" && radius <= 0) {
+    if (temporal_mode_supplied && temporal_mode == "rolling" && radius <= 0) {
         vsapi->freeNode(src);
         vsapi->setError(out, "BM3Dv2: rolling temporal mode requires radius greater than zero");
         return;
@@ -2390,10 +2324,10 @@ static void VS_CC BM3Dv2Create(
 
     if (radius > 0) {
         vsapi->freeNode(src);
-        if (temporal_mode == "fused") {
-            BM3DCreateImpl(in, out, userData, core, vsapi, true);
-        } else if (temporal_mode == "rolling") {
-            RollingCreate(in, out, rolling_chunk, core, vsapi);
+        if (temporal_mode == "rolling") {
+            RollingCreate(
+                in, out, rolling_chunk, rolling_cache_chunks,
+                rolling_cache_limit, cache_adaptive, core, vsapi);
         } else {
             auto plugin = vsapi->getPluginById(PLUGIN_ID, core);
             auto map = copy_bm3d_args(in, vsapi);
@@ -2508,6 +2442,8 @@ VS_EXTERNAL_API(void) VapourSynthPluginInit(
         "zero_init:int:opt;"
         "temporal_mode:data:opt;"
         "rolling_chunk:int:opt;"
+        "rolling_cache_chunks:int:opt;"
+        "rolling_cache_limit:int:opt;"
     };
 
     registerFunc("BM3D", bm3d_args, BM3DCreate, nullptr, plugin);

--- a/rtc_source/source.cpp
+++ b/rtc_source/source.cpp
@@ -173,12 +173,14 @@ struct BM3DData {
     bool chroma;
     bool process[3]; // sigma != 0
     bool final_;
+    bool fused;
     std::string bm_error_s[3];
     std::string transform_2d_s[3];
     std::string transform_1d_s[3];
     bool zero_init;
 
     int d_pitch;
+    size_t params_offset;
 
     CUdevice device;
     CUcontext context; // use primary context
@@ -193,7 +195,7 @@ static std::variant<CUmodule, std::string> compile(
     float sigma, int block_step, int bm_range,
     int radius, int ps_num, int ps_range,
     bool chroma, float sigma_u, float sigma_v,
-    bool final_,
+    bool final_, bool fused,
     const std::string & bm_error_s,
     const std::string & transform_2d_s,
     const std::string & transform_1d_s,
@@ -226,6 +228,7 @@ static std::variant<CUmodule, std::string> compile(
         << "__device__ static const bool temporal = " << (radius > 0) << ";\n"
         << "__device__ static const bool chroma = " << chroma << ";\n"
         << "__device__ static const bool final_ = " << final_ << ";\n"
+        << "__device__ static const bool fused = " << fused << ";\n"
         << "__device__ static const float extractor = " << extractor << ";\n"
         << "__device__ static const float FLT_MAX = "
             << std::numeric_limits<float>::max() << ";\n"
@@ -357,9 +360,13 @@ static std::variant<CUgraphExec, std::string> get_graphexec(
     CUgraphNode n_kernel;
     {
         CUgraphNode dependencies[] { n_HtoD, n_memset };
+        int source_temporal_width = temporal_width;
+        CUdeviceptr fused_params {};
+        int fused_center = 0;
 
         void * kernel_args[] {
-            &d_res, &d_src
+            &d_res, &d_src,
+            &source_temporal_width, &fused_params, &fused_center
         };
 
         CUDA_KERNEL_NODE_PARAMS node_params {
@@ -381,11 +388,9 @@ static std::variant<CUgraphExec, std::string> get_graphexec(
     CUgraphNode n_DtoH;
     {
         CUgraphNode dependencies[] { n_kernel };
-
         size_t logical_height {
             static_cast<size_t>(num_planes * temporal_width * 2 * height)
         };
-
         CUDA_MEMCPY3D copy_params {
             .srcMemoryType = CU_MEMORYTYPE_DEVICE,
             .srcDevice = d_res,
@@ -412,20 +417,166 @@ static std::variant<CUgraphExec, std::string> get_graphexec(
     return graphexec;
 }
 
+static std::variant<CUgraphExec, std::string> get_fused_graphexec(
+    CUdeviceptr d_res, CUdeviceptr d_src, float * h_res,
+    CUdeviceptr d_params, int * h_params,
+    int width, int height, int stride,
+    int block_step, int radius, bool chroma, bool final_,
+    CUcontext context, CUfunction function, CUfunction normalize_function
+) noexcept {
+    const auto set_error = [](const std::string & error_message) {
+        return error_message;
+    };
+
+    size_t pitch { stride * sizeof(float) };
+    int centers { 2 * radius + 1 };
+    int source_temporal_width { 4 * radius + 1 };
+    int num_planes { chroma ? 3 : 1 };
+    size_t source_height {
+        static_cast<size_t>(final_ ? 2 : 1) * num_planes *
+            source_temporal_width * height
+    };
+
+    CUgraph graph_;
+    checkError(cuGraphCreate(&graph_, 0));
+    Resource<CUgraph, cuGraphDestroy> graph { graph_ };
+
+    CUgraphNode n_HtoD;
+    CUDA_MEMCPY3D source_copy {
+        .srcMemoryType = CU_MEMORYTYPE_HOST,
+        .srcHost = h_res,
+        .srcPitch = pitch,
+        .dstMemoryType = CU_MEMORYTYPE_DEVICE,
+        .dstDevice = d_src,
+        .dstPitch = pitch,
+        .WidthInBytes = static_cast<size_t>(width) * sizeof(float),
+        .Height = source_height,
+        .Depth = 1,
+    };
+    checkError(cuGraphAddMemcpyNode(
+        &n_HtoD, graph, nullptr, 0, &source_copy, context));
+
+    CUgraphNode n_params;
+    const size_t params_size =
+        (1 + 2 * static_cast<size_t>(centers)) * sizeof(int);
+    CUDA_MEMCPY3D params_copy {
+        .srcMemoryType = CU_MEMORYTYPE_HOST,
+        .srcHost = h_params,
+        .srcPitch = params_size,
+        .dstMemoryType = CU_MEMORYTYPE_DEVICE,
+        .dstDevice = d_params,
+        .dstPitch = params_size,
+        .WidthInBytes = params_size,
+        .Height = 1,
+        .Depth = 1,
+    };
+    checkError(cuGraphAddMemcpyNode(
+        &n_params, graph, nullptr, 0, &params_copy, context));
+
+    CUgraphNode n_memset;
+    CUDA_MEMSET_NODE_PARAMS memset_params {
+        .dst = d_res,
+        .pitch = pitch,
+        .value = 0,
+        .elementSize = 4,
+        .width = static_cast<size_t>(width),
+        .height = static_cast<size_t>(centers) * num_planes * 2 * height,
+    };
+    checkError(cuGraphAddMemsetNode(
+        &n_memset, graph, nullptr, 0, &memset_params, context));
+
+    std::vector<CUgraphNode> center_nodes(centers);
+    const size_t center_stride = static_cast<size_t>(num_planes) * 2 * height * pitch;
+    for (int center = 0; center < centers; ++center) {
+        CUgraphNode dependencies[] { n_HtoD, n_params, n_memset };
+        CUdeviceptr center_res = d_res + center * center_stride;
+        int fused_center = center;
+        void * kernel_args[] {
+            &center_res, &d_src,
+            &source_temporal_width, &d_params, &fused_center
+        };
+
+        CUDA_KERNEL_NODE_PARAMS node_params {
+            .func = function,
+            .gridDimX = static_cast<unsigned int>((width + (4 * block_step - 1)) / (4 * block_step)),
+            .gridDimY = static_cast<unsigned int>((height + (block_step - 1)) / block_step),
+            .gridDimZ = 1,
+            .blockDimX = 32,
+            .blockDimY = 1,
+            .blockDimZ = 1,
+            .sharedMemBytes = 0,
+            .kernelParams = kernel_args,
+        };
+        checkError(cuGraphAddKernelNode(
+            &center_nodes[center], graph,
+            dependencies, std::size(dependencies), &node_params));
+    }
+
+    CUgraphNode n_normalize;
+    {
+        int normalize_width = width;
+        int normalize_height = height;
+        int normalize_stride = stride;
+        void * kernel_args[] {
+            &d_res, &normalize_width, &normalize_height, &normalize_stride,
+            &num_planes, &centers
+        };
+        CUDA_KERNEL_NODE_PARAMS node_params {
+            .func = normalize_function,
+            .gridDimX = static_cast<unsigned int>((width + 255) / 256),
+            .gridDimY = static_cast<unsigned int>(height),
+            .gridDimZ = static_cast<unsigned int>(num_planes),
+            .blockDimX = 256,
+            .blockDimY = 1,
+            .blockDimZ = 1,
+            .sharedMemBytes = 0,
+            .kernelParams = kernel_args,
+        };
+        checkError(cuGraphAddKernelNode(
+            &n_normalize, graph,
+            center_nodes.data(), center_nodes.size(), &node_params));
+    }
+
+    CUgraphNode dependencies[] { n_normalize };
+    for (int plane = 0; plane < num_planes; ++plane) {
+        const size_t plane_offset = static_cast<size_t>(plane) * 2 * height * pitch;
+        CUDA_MEMCPY3D copy_params {
+            .srcMemoryType = CU_MEMORYTYPE_DEVICE,
+            .srcDevice = d_res + plane_offset,
+            .srcPitch = pitch,
+            .dstMemoryType = CU_MEMORYTYPE_HOST,
+            .dstHost = reinterpret_cast<char *>(h_res) + plane_offset,
+            .dstPitch = pitch,
+            .WidthInBytes = static_cast<size_t>(width) * sizeof(float),
+            .Height = static_cast<size_t>(height),
+            .Depth = 1,
+        };
+        CUgraphNode n_DtoH;
+        checkError(cuGraphAddMemcpyNode(
+            &n_DtoH, graph,
+            dependencies, std::size(dependencies), &copy_params, context));
+    }
+
+    CUgraphExec graphexec;
+#if CUDA_VERSION >= 12000
+    checkError(cuGraphInstantiate(&graphexec, graph, 0));
+#else
+    checkError(cuGraphInstantiate(&graphexec, graph, nullptr, nullptr, 0));
+#endif
+    return graphexec;
+}
+
 static inline void Aggregation(
     float * VS_RESTRICT dstp, int dst_stride,
     const float * VS_RESTRICT srcp, int src_stride,
     int width, int height
 ) noexcept {
-
     const float * wdst = srcp;
     const float * weight = &srcp[height * src_stride];
-
     for (int y = 0; y < height; ++y) {
         for (int x = 0; x < width; ++x) {
             dstp[x] = wdst[x] / weight[x];
         }
-
         dstp += dst_stride;
         wdst += src_stride;
         weight += src_stride;
@@ -439,7 +590,7 @@ static void VS_CC BM3DInit(
 
     BM3DData * d = static_cast<BM3DData *>(*instanceData);
 
-    if (d->radius) {
+    if (d->radius && !d->fused) {
         VSVideoInfo vi = *d->vi;
         vi.height *= 2 * (2 * d->radius + 1);
         vsapi->setVideoInfo(&vi, 1, node);
@@ -456,8 +607,11 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
     auto d = static_cast<BM3DData *>(*instanceData);
 
     if (activationReason == arInitial) {
-        int start_frame = std::max(n - d->radius, 0);
-        int end_frame = std::min(n + d->radius, d->vi->numFrames - 1);
+        int64_t request_radius = d->fused ? 2LL * d->radius : d->radius;
+        int start_frame = static_cast<int>(
+            std::max<int64_t>(static_cast<int64_t>(n) - request_radius, 0));
+        int end_frame = static_cast<int>(std::min<int64_t>(
+            static_cast<int64_t>(n) + request_radius, d->vi->numFrames - 1));
 
         for (int i = start_frame; i <= end_frame; ++i) {
             vsapi->requestFrameFilter(i, d->node, frameCtx);
@@ -471,7 +625,14 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
         int radius = d->radius;
         int temporal_width = 2 * radius + 1;
         bool final_ = d->final_;
-        int num_input_frames = temporal_width * (final_ ? 2 : 1); // including ref
+        bool fused = d->fused;
+        int64_t request_radius = fused ? 2LL * radius : radius;
+        int start_frame = static_cast<int>(
+            std::max<int64_t>(static_cast<int64_t>(n) - request_radius, 0));
+        int end_frame = static_cast<int>(std::min<int64_t>(
+            static_cast<int64_t>(n) + request_radius, d->vi->numFrames - 1));
+        int input_width = fused ? end_frame - start_frame + 1 : temporal_width;
+        int num_input_frames = input_width * (final_ ? 2 : 1); // including ref
 
         using freeFrame_t = decltype(vsapi->freeFrame);
         const std::vector srcs = [&](){
@@ -480,8 +641,9 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
             temp.reserve(num_input_frames);
 
             if (final_) {
-                for (int i = -radius; i <= radius; ++i) {
-                    int clamped_n = std::clamp(n + i, 0, d->vi->numFrames - 1);
+                for (int i = 0; i < input_width; ++i) {
+                    int clamped_n = fused ? start_frame + i :
+                        std::clamp(n - radius + i, 0, d->vi->numFrames - 1);
                     temp.emplace_back(
                         vsapi->getFrameFilter(clamped_n, d->ref_node, frameCtx),
                         vsapi->freeFrame
@@ -489,8 +651,9 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
                 }
             }
 
-            for (int i = -radius; i <= radius; ++i) {
-                int clamped_n = std::clamp(n + i, 0, d->vi->numFrames - 1);
+            for (int i = 0; i < input_width; ++i) {
+                int clamped_n = fused ? start_frame + i :
+                    std::clamp(n - radius + i, 0, d->vi->numFrames - 1);
                 temp.emplace_back(
                     vsapi->getFrameFilter(clamped_n, d->node, frameCtx),
                     vsapi->freeFrame
@@ -500,10 +663,11 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
             return temp;
         }();
 
-        const VSFrameRef * src = srcs[radius + (final_ ? temporal_width : 0)].get();
+        int center_index = fused ? n - start_frame : radius;
+        const VSFrameRef * src = srcs[center_index + (final_ ? input_width : 0)].get();
 
         std::unique_ptr<VSFrameRef, const freeFrame_t &> dst { nullptr, vsapi->freeFrame };
-        if (radius) {
+        if (radius && !fused) {
             dst.reset(
                 vsapi->newVideoFrame(
                     d->vi->format, d->vi->width,
@@ -569,9 +733,9 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
             float * h_src = h_res;
             for (int outer = 0; outer < (final_ ? 2 : 1); ++outer) {
                 for (int i = 0; i < std::ssize(d->process); ++i) {
-                    for (int j = 0; j < temporal_width; ++j) {
+                    for (int j = 0; j < input_width; ++j) {
                         if (i == 0 || d->process[i]) {
-                            auto current_src = srcs[j + outer * temporal_width].get();
+                            auto current_src = srcs[j + outer * input_width].get();
 
                             vs_bitblt(
                                 h_src, d_pitch,
@@ -581,6 +745,22 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
                         }
                         h_src += d_stride * height;
                     }
+                    if (fused) {
+                        h_src += d_stride * height * (4 * radius + 1 - input_width);
+                    }
+                }
+            }
+
+            if (fused) {
+                int * params = reinterpret_cast<int *>(
+                    reinterpret_cast<char *>(h_res) + d->params_offset);
+                params[0] = input_width;
+                for (int center = 0; center < temporal_width; ++center) {
+                    int center_frame = static_cast<int>(std::clamp<int64_t>(
+                        static_cast<int64_t>(n) - radius + center,
+                        0, d->vi->numFrames - 1));
+                    params[1 + 2 * center] = center_frame - start_frame;
+                    params[2 + 2 * center] = n - center_frame + radius;
                 }
             }
 
@@ -591,27 +771,25 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
             float * h_dst = h_res;
             for (int plane = 0; plane < std::ssize(d->process); ++plane) {
                 if (!d->process[plane]) {
-                    h_dst += d_stride * height * 2 * temporal_width;
+                    h_dst += d_stride * height * 2 * (fused ? 1 : temporal_width);
                     continue;
                 }
 
                 float * dstp = reinterpret_cast<float *>(
                     vsapi->getWritePtr(dst.get(), plane));
 
-                if (radius) {
+                if (radius && !fused) {
                     vs_bitblt(
                         dstp, s_pitch, h_dst, d_pitch,
                         width_bytes, height * 2 * temporal_width
                     );
+                } else if (fused) {
+                    vs_bitblt(dstp, s_pitch, h_dst, d_pitch, width_bytes, height);
                 } else {
-                    Aggregation(
-                        dstp, s_stride,
-                        h_dst, d_stride,
-                        width, height
-                    );
+                    Aggregation(dstp, s_stride, h_dst, d_stride, width, height);
                 }
 
-                h_dst += d_stride * height * 2 * temporal_width;
+                h_dst += d_stride * height * 2 * (fused ? 1 : temporal_width);
             }
         } else { // !d->chroma
             for (int plane = 0; plane < d->vi->format->numPlanes; plane++) {
@@ -635,6 +813,22 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
                         width_bytes, height
                     );
                     h_src += d_stride * height;
+                    if (fused && (i + 1) % input_width == 0) {
+                        h_src += d_stride * height * (4 * radius + 1 - input_width);
+                    }
+                }
+
+                if (fused) {
+                    int * params = reinterpret_cast<int *>(
+                        reinterpret_cast<char *>(h_res) + d->params_offset);
+                    params[0] = input_width;
+                    for (int center = 0; center < temporal_width; ++center) {
+                        int center_frame = static_cast<int>(std::clamp<int64_t>(
+                            static_cast<int64_t>(n) - radius + center,
+                            0, d->vi->numFrames - 1));
+                        params[1 + 2 * center] = center_frame - start_frame;
+                        params[2 + 2 * center] = n - center_frame + radius;
+                    }
                 }
 
                 checkError(cuGraphLaunch(graphexec, stream));
@@ -644,17 +838,15 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
                 float * dstp = reinterpret_cast<float *>(
                     vsapi->getWritePtr(dst.get(), plane));
 
-                if (radius) {
+                if (radius && !fused) {
                     vs_bitblt(
                         dstp, s_pitch, h_res, d_pitch,
                         width_bytes, height * 2 * temporal_width
                     );
+                } else if (fused) {
+                    vs_bitblt(dstp, s_pitch, h_res, d_pitch, width_bytes, height);
                 } else {
-                    Aggregation(
-                        dstp, s_stride,
-                        h_res, d_stride,
-                        width, height
-                    );
+                    Aggregation(dstp, s_stride, h_res, d_stride, width, height);
                 }
             }
         }
@@ -666,7 +858,7 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
         d->resources_lock.unlock();
         d->semaphore.release();
 
-        if (radius) {
+        if (radius && !fused) {
             VSMap * dst_prop { vsapi->getFramePropsRW(dst.get()) };
 
             vsapi->propSetInt(dst_prop, "BM3D_V_radius", d->radius, paReplace);
@@ -701,9 +893,9 @@ static void VS_CC BM3DFree(
     cuDevicePrimaryCtxRelease(device);
 }
 
-static void VS_CC BM3DCreate(
+static void BM3DCreateImpl(
     const VSMap *in, VSMap *out, void *userData,
-    VSCore *core, const VSAPI *vsapi
+    VSCore *core, const VSAPI *vsapi, bool fused
 ) noexcept {
 
     auto d { std::make_unique<BM3DData>() };
@@ -746,6 +938,7 @@ static void VS_CC BM3DCreate(
         final_ = true;
     }
     d->final_ = final_;
+    d->fused = fused;
 
     float sigma[3];
     for (int i = 0; i < std::ssize(sigma); ++i) {
@@ -802,6 +995,9 @@ static void VS_CC BM3DCreate(
     }();
     if (radius < 0) {
         return set_error("\"radius\" must be non-negative");
+    }
+    if (fused && radius > (std::numeric_limits<int>::max() - 1) / 4) {
+        return set_error("\"radius\" is too large for fused temporal processing");
     }
     d->radius = radius;
 
@@ -924,6 +1120,39 @@ static void VS_CC BM3DCreate(
         return (temp ? std::ldexp(1.0f, temp) : 0.0f);
     }();
 
+    const int max_width {
+        d->process[0] ? width : width >> d->vi->format->subSamplingW
+    };
+    const int max_height {
+        d->process[0] ? height : height >> d->vi->format->subSamplingH
+    };
+    const int num_planes { chroma ? 3 : 1 };
+    const int temporal_width = 2 * radius + 1;
+    const int source_temporal_width = fused ? 4 * radius + 1 : temporal_width;
+    if (fused) {
+        const size_t min_temporal_stride =
+            static_cast<size_t>(max_width) * max_height;
+        const size_t max_kernel_offset = std::numeric_limits<int>::max();
+        if (
+            min_temporal_stride > max_kernel_offset ||
+            static_cast<size_t>(source_temporal_width) >
+                max_kernel_offset / min_temporal_stride ||
+            static_cast<size_t>(num_planes) > max_kernel_offset /
+                (min_temporal_stride * source_temporal_width)) {
+            return set_error("\"radius\" is too large for the clip dimensions");
+        }
+    }
+    const size_t source_rows = static_cast<size_t>(final_ ? 2 : 1) *
+        static_cast<size_t>(num_planes) * source_temporal_width * max_height;
+    const size_t result_rows = static_cast<size_t>(num_planes) *
+        temporal_width * 2 * max_height;
+    const size_t buffer_rows = std::max(source_rows, result_rows);
+    const size_t params_size = fused ?
+        (1 + 2 * static_cast<size_t>(temporal_width)) * sizeof(int) : 0;
+    const size_t min_pitch = static_cast<size_t>(max_width) * sizeof(float);
+    const size_t params_rows = fused ?
+        (params_size + min_pitch - 1) / min_pitch : 0;
+
     d->semaphore.current.store(num_copy_engines - 1, std::memory_order::relaxed);
 
     // GPU related
@@ -950,36 +1179,53 @@ static void VS_CC BM3DCreate(
 
         d->resources.reserve(num_copy_engines);
 
-        const int max_width { d->process[0] ? width : width >> d->vi->format->subSamplingW };
-        const int max_height { d->process[0] ? height : height >> d->vi->format->subSamplingH };
-
-        const int num_planes { chroma ? 3 : 1 };
-        const int temporal_width = 2 * radius + 1;
-
         size_t d_pitch;
         int d_stride;
         CUfunction functions[3];
+        CUfunction normalize_functions[3];
         for (int i = 0; i < num_copy_engines; ++i) {
             Resource<CUdeviceptr, cuMemFree> d_src {};
             if (i == 0) {
                 checkError(cuMemAllocPitch(
                     &d_src.data, &d_pitch, max_width * sizeof(float),
-                    (final_ ? 2 : 1) * num_planes * temporal_width * max_height, 4
+                    fused ? buffer_rows + params_rows : source_rows, 4
                 ));
+                if (d_pitch > static_cast<size_t>(std::numeric_limits<int>::max())) {
+                    d_src = CUdeviceptr {};
+                    cuCtxPopCurrent(nullptr);
+                    cuDevicePrimaryCtxRelease(d->device);
+                    return set_error("device pitch exceeds the supported range");
+                }
                 d_stride = static_cast<int>(d_pitch / sizeof(float));
+                if (fused) {
+                    const size_t temporal_stride =
+                        static_cast<size_t>(max_height) * d_stride;
+                    const size_t max_kernel_offset = std::numeric_limits<int>::max();
+                    if (
+                        temporal_stride > max_kernel_offset ||
+                        static_cast<size_t>(source_temporal_width) >
+                            max_kernel_offset / temporal_stride ||
+                        static_cast<size_t>(num_planes) > max_kernel_offset /
+                            (temporal_stride * source_temporal_width)) {
+                        d_src = CUdeviceptr {};
+                        cuCtxPopCurrent(nullptr);
+                        cuDevicePrimaryCtxRelease(d->device);
+                        return set_error("\"radius\" is too large for the device pitch");
+                    }
+                }
                 d->d_pitch = static_cast<int>(d_pitch);
+                d->params_offset = buffer_rows * d_pitch;
             } else {
                 checkError(cuMemAlloc(&d_src.data,
-                    (final_ ? 2 : 1) * num_planes * temporal_width * max_height * d_pitch));
+                    fused ? buffer_rows * d_pitch + params_size : source_rows * d_pitch));
             }
 
             Resource<CUdeviceptr, cuMemFree> d_res {};
-            checkError(cuMemAlloc(&d_res.data,
-                num_planes * temporal_width * 2 * max_height * d_pitch));
+            checkError(cuMemAlloc(&d_res.data, result_rows * d_pitch));
 
             Resource<float *, cuMemFreeHost> h_res {};
             checkError(cuMemAllocHost(reinterpret_cast<void **>(&h_res.data),
-                num_planes * temporal_width * 2 * max_height * d_pitch));
+                buffer_rows * d_pitch + params_size));
 
             Resource<CUstream, cuStreamDestroy> stream {};
             checkError(cuStreamCreate(&stream.data, CU_STREAM_NON_BLOCKING));
@@ -992,7 +1238,7 @@ static void VS_CC BM3DCreate(
                         sigma[0], block_step[0], bm_range[0],
                         radius, ps_num[0], ps_range[0],
                         true, sigma[1], sigma[2],
-                        final_,
+                        final_, fused,
                         d->bm_error_s[0],
                         d->transform_2d_s[0], d->transform_1d_s[0],
                         extractor,
@@ -1006,14 +1252,24 @@ static void VS_CC BM3DCreate(
                     }
 
                     checkError(cuModuleGetFunction(&functions[0], d->modules[0], "bm3d"));
+                    if (fused) {
+                        checkError(cuModuleGetFunction(
+                            &normalize_functions[0], d->modules[0], "temporal_normalize"));
+                    }
                 }
 
-                const auto result = get_graphexec(
+                const auto result = fused ? get_fused_graphexec(
+                    d_res, d_src, h_res,
+                    d_src.data + d->params_offset,
+                    reinterpret_cast<int *>(reinterpret_cast<char *>(h_res.data) + d->params_offset),
+                    width, height, d_stride,
+                    block_step[0], radius, true, final_, d->context,
+                    functions[0], normalize_functions[0]
+                ) : get_graphexec(
                     d_res, d_src, h_res,
                     width, height, d_stride,
-                    block_step[0], radius,
-                    true, final_, d->context, functions[0]
-                );
+                    block_step[0], radius, true, final_, d->context,
+                    functions[0]);
 
                 if (std::holds_alternative<CUgraphExec>(result)) {
                     graphexecs[0] = std::get<CUgraphExec>(result);
@@ -1034,7 +1290,7 @@ static void VS_CC BM3DCreate(
                                 plane_width, plane_height, d_stride,
                                 sigma[plane], block_step[plane], bm_range[plane],
                                 radius, ps_num[plane], ps_range[plane],
-                                false, 0.0f, 0.0f, final_,
+                                false, 0.0f, 0.0f, final_, fused,
                                 d->bm_error_s[plane],
                                 d->transform_2d_s[plane], d->transform_1d_s[plane],
                                 extractor,
@@ -1049,14 +1305,25 @@ static void VS_CC BM3DCreate(
 
                             checkError(cuModuleGetFunction(
                                 &functions[plane], d->modules[plane], "bm3d"));
+                            if (fused) {
+                                checkError(cuModuleGetFunction(
+                                    &normalize_functions[plane], d->modules[plane],
+                                    "temporal_normalize"));
+                            }
                         }
 
-                        const auto result = get_graphexec(
+                        const auto result = fused ? get_fused_graphexec(
+                            d_res, d_src, h_res,
+                            d_src.data + d->params_offset,
+                            reinterpret_cast<int *>(reinterpret_cast<char *>(h_res.data) + d->params_offset),
+                            plane_width, plane_height, d_stride,
+                            block_step[plane], radius, false, final_, d->context,
+                            functions[plane], normalize_functions[plane]
+                        ) : get_graphexec(
                             d_res, d_src, h_res,
                             plane_width, plane_height, d_stride,
-                            block_step[plane], radius,
-                            false, final_, d->context, functions[plane]
-                        );
+                            block_step[plane], radius, false, final_, d->context,
+                            functions[plane]);
 
                         if (std::holds_alternative<CUgraphExec>(result)) {
                             graphexecs[plane] = std::get<CUgraphExec>(result);
@@ -1080,10 +1347,17 @@ static void VS_CC BM3DCreate(
     }
 
     vsapi->createFilter(
-        in, out, "BM3D",
+        in, out, fused ? "BM3Dv2" : "BM3D",
         BM3DInit, BM3DGetFrame, BM3DFree,
         fmParallel, 0, d.release(), core
     );
+}
+
+static void VS_CC BM3DCreate(
+    const VSMap *in, VSMap *out, void *userData,
+    VSCore *core, const VSAPI *vsapi
+) noexcept {
+    BM3DCreateImpl(in, out, userData, core, vsapi, false);
 }
 
 struct VAggregateData {
@@ -1251,17 +1525,42 @@ static void VS_CC VAggregateCreate(
 
     auto d { std::make_unique<VAggregateData>() };
 
+    const auto set_error = [&](const std::string & error_message) {
+        vsapi->setError(out, ("VAggregate: " + error_message).c_str());
+        if (d->src_node) {
+            vsapi->freeNode(d->src_node);
+        }
+        if (d->node) {
+            vsapi->freeNode(d->node);
+        }
+    };
+
     d->node = vsapi->propGetNode(in, "clip", 0, nullptr);
     auto vi = vsapi->getVideoInfo(d->node);
     d->src_node = vsapi->propGetNode(in, "src", 0, nullptr);
     d->src_vi = vsapi->getVideoInfo(d->src_node);
+
+    const int num_planes = d->src_vi->format->numPlanes;
+    if (num_planes > static_cast<int>(d->process.size())) {
+        return set_error("source clip has too many planes");
+    }
 
     d->radius = (vi->height / d->src_vi->height - 2) / 4;
 
     d->process.fill(false);
     int num_planes_args = vsapi->propNumElements(in, "planes");
     for (int i = 0; i < num_planes_args; ++i) {
-        int plane = vsapi->propGetInt(in, "planes", i, nullptr);
+        int error;
+        int plane = int64ToIntS(vsapi->propGetInt(in, "planes", i, &error));
+        if (error) {
+            return set_error("\"planes\" must contain only integers");
+        }
+        if (plane < 0 || plane >= num_planes) {
+            return set_error("\"planes\" contains an out-of-range plane index");
+        }
+        if (d->process[plane]) {
+            return set_error("\"planes\" contains a duplicate plane index");
+        }
         d->process[plane] = true;
     }
 
@@ -1308,6 +1607,17 @@ static void VS_CC BM3Dv2Create(
         return ;
     }
 
+    int error;
+    int radius = int64ToIntS(vsapi->propGetInt(in, "radius", 0, &error));
+    if (error) {
+        radius = 0;
+    }
+    if (radius > 0) {
+        vsapi->freeNode(src);
+        BM3DCreateImpl(in, out, userData, core, vsapi, true);
+        return;
+    }
+
     auto plugin = vsapi->getPluginById(PLUGIN_ID, core);
     auto map = vsapi->invoke(plugin, "BM3D", in);
     if (auto error = vsapi->getError(map); error) {
@@ -1317,11 +1627,6 @@ static void VS_CC BM3Dv2Create(
         return ;
     }
 
-    int error;
-    int radius = vsapi->propGetInt(in, "radius", 0, &error);
-    if (error) {
-        radius = 0;
-    }
     if (radius == 0) {
         // spatial BM3D should handle everything itself
         auto node = vsapi->propGetNode(map, "clip", 0, nullptr);

--- a/rtc_source/source.cpp
+++ b/rtc_source/source.cpp
@@ -32,6 +32,7 @@
 #include <shared_mutex>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <type_traits>
 #include <unordered_map>
@@ -195,7 +196,7 @@ static std::variant<CUmodule, std::string> compile(
     float sigma, int block_step, int bm_range,
     int radius, int ps_num, int ps_range,
     bool chroma, float sigma_u, float sigma_v,
-    bool final_, bool fused,
+    bool final_, bool fused, bool rolling,
     const std::string & bm_error_s,
     const std::string & transform_2d_s,
     const std::string & transform_1d_s,
@@ -229,6 +230,7 @@ static std::variant<CUmodule, std::string> compile(
         << "__device__ static const bool chroma = " << chroma << ";\n"
         << "__device__ static const bool final_ = " << final_ << ";\n"
         << "__device__ static const bool fused = " << fused << ";\n"
+        << "__device__ static const bool rolling = " << rolling << ";\n"
         << "__device__ static const float extractor = " << extractor << ";\n"
         << "__device__ static const float FLT_MAX = "
             << std::numeric_limits<float>::max() << ";\n"
@@ -555,6 +557,232 @@ static std::variant<CUgraphExec, std::string> get_fused_graphexec(
         checkError(cuGraphAddMemcpyNode(
             &n_DtoH, graph,
             dependencies, std::size(dependencies), &copy_params, context));
+    }
+
+    CUgraphExec graphexec;
+#if CUDA_VERSION >= 12000
+    checkError(cuGraphInstantiate(&graphexec, graph, 0));
+#else
+    checkError(cuGraphInstantiate(&graphexec, graph, nullptr, nullptr, 0));
+#endif
+    return graphexec;
+}
+
+struct RollingGroup {
+    int first_plane;
+    int planes;
+    int width;
+    int height;
+    size_t source_row;
+    size_t accum_row;
+    CUfunction bm3d;
+    CUfunction scatter;
+    CUfunction normalize;
+    float sigma;
+    float sigma_u;
+    float sigma_v;
+    int block_step;
+    int bm_range;
+    int ps_num;
+    int ps_range;
+};
+
+static std::variant<CUgraphExec, std::string> get_rolling_graphexec(
+    CUdeviceptr d_accum, CUdeviceptr d_scratch, CUdeviceptr d_src,
+    float * h_src, float * h_output, CUdeviceptr d_params, int * h_params,
+    int width, int height, int stride,
+    const int block_step[3], int radius, int chunk_size,
+    int process_mask, int video_planes, int subsampling_w, int subsampling_h,
+    bool chroma, bool final_, float extractor, CUcontext context,
+    const std::vector<RollingGroup> & groups
+) noexcept {
+    const auto set_error = [](const std::string & error_message) {
+        return error_message;
+    };
+    const size_t pitch = static_cast<size_t>(stride) * sizeof(float);
+    const int temporal_width = 2 * radius + 1;
+    const int source_width = chunk_size + 4 * radius;
+    const int centers = chunk_size + 2 * radius;
+    const int copy_width = (process_mask & 1) ? width : width >> subsampling_w;
+    size_t source_rows = 0;
+    size_t accum_rows = 0;
+    for (const auto & group : groups) {
+        source_rows = std::max(source_rows,
+            group.source_row + static_cast<size_t>(final_ ? 2 : 1) *
+                group.planes * source_width * group.height);
+        accum_rows = std::max(accum_rows,
+            group.accum_row + static_cast<size_t>(chunk_size) *
+                group.planes * 2 * group.height);
+    }
+
+    CUgraph graph_;
+    checkError(cuGraphCreate(&graph_, 0));
+    Resource<CUgraph, cuGraphDestroy> graph { graph_ };
+
+    CUgraphNode source_copy;
+    CUDA_MEMCPY3D source_params {
+        .srcMemoryType = CU_MEMORYTYPE_HOST,
+        .srcHost = h_src,
+        .srcPitch = pitch,
+        .dstMemoryType = CU_MEMORYTYPE_DEVICE,
+        .dstDevice = d_src,
+        .dstPitch = pitch,
+        .WidthInBytes = static_cast<size_t>(copy_width) * sizeof(float),
+        .Height = source_rows,
+        .Depth = 1,
+    };
+    checkError(cuGraphAddMemcpyNode(
+        &source_copy, graph, nullptr, 0, &source_params, context));
+
+    CUgraphNode params_copy;
+    const size_t params_size = (1 + static_cast<size_t>(centers)) * sizeof(int);
+    CUDA_MEMCPY3D params_params {
+        .srcMemoryType = CU_MEMORYTYPE_HOST,
+        .srcHost = h_params,
+        .srcPitch = params_size,
+        .dstMemoryType = CU_MEMORYTYPE_DEVICE,
+        .dstDevice = d_params,
+        .dstPitch = params_size,
+        .WidthInBytes = params_size,
+        .Height = 1,
+        .Depth = 1,
+    };
+    checkError(cuGraphAddMemcpyNode(
+        &params_copy, graph, nullptr, 0, &params_params, context));
+
+    CUgraphNode accum_clear;
+    CUDA_MEMSET_NODE_PARAMS accum_memset {
+        .dst = d_accum,
+        .pitch = pitch,
+        .value = 0,
+        .elementSize = 4,
+        .width = static_cast<size_t>(copy_width),
+        .height = accum_rows,
+    };
+    checkError(cuGraphAddMemsetNode(
+        &accum_clear, graph, nullptr, 0, &accum_memset, context));
+
+    CUgraphNode previous_group {};
+    for (const auto & group : groups) {
+        CUgraphNode previous = previous_group;
+        for (int center = 0; center < centers; ++center) {
+            CUgraphNode scratch_clear;
+            CUgraphNode initial_dependencies[] { source_copy, params_copy, accum_clear };
+            const CUgraphNode * dependencies = previous ? &previous : initial_dependencies;
+            const size_t dependency_count = previous ? 1 : std::size(initial_dependencies);
+            CUDA_MEMSET_NODE_PARAMS scratch_memset {
+                .dst = d_scratch,
+                .pitch = pitch,
+                .value = 0,
+                .elementSize = 4,
+                .width = static_cast<size_t>(group.width),
+                .height = static_cast<size_t>(group.planes) * temporal_width * 2 * group.height,
+            };
+            checkError(cuGraphAddMemsetNode(
+                &scratch_clear, graph, dependencies, dependency_count,
+                &scratch_memset, context));
+
+            CUdeviceptr center_source = d_src + group.source_row * stride * sizeof(float);
+            int source_temporal_width = source_width;
+            CUdeviceptr params = d_params;
+            void * kernel_args[] {
+                &d_scratch, &center_source,
+                &source_temporal_width, &params, &center
+            };
+            const int center_block_step = group.block_step;
+            CUgraphNode center_node;
+            CUDA_KERNEL_NODE_PARAMS kernel_params {
+                .func = group.bm3d,
+                .gridDimX = static_cast<unsigned int>((group.width +
+                    (4 * center_block_step - 1)) / (4 * center_block_step)),
+                .gridDimY = static_cast<unsigned int>(
+                    (group.height + (center_block_step - 1)) / center_block_step),
+                .gridDimZ = 1,
+                .blockDimX = 32,
+                .blockDimY = 1,
+                .blockDimZ = 1,
+                .sharedMemBytes = 0,
+                .kernelParams = kernel_args,
+            };
+            checkError(cuGraphAddKernelNode(
+                &center_node, graph, &scratch_clear, 1, &kernel_params));
+
+            CUgraphNode scatter_node;
+            CUdeviceptr group_accum = d_accum + group.accum_row * stride * sizeof(float);
+            int group_planes = group.planes;
+            int center_width = group.width;
+            int center_height = group.height;
+            int center_stride = stride;
+            int center_radius = radius;
+            void * scatter_args[] {
+                &group_accum, &d_scratch, &d_params,
+                &center_width, &center_height, &center_stride,
+                &group_planes, &center_radius, &chunk_size, &center
+            };
+            CUDA_KERNEL_NODE_PARAMS scatter_params {
+                .func = nullptr,
+                .gridDimX = static_cast<unsigned int>((group.width + 255) / 256),
+                .gridDimY = static_cast<unsigned int>(group.height),
+                .gridDimZ = static_cast<unsigned int>(group.planes),
+                .blockDimX = 256,
+                .blockDimY = 1,
+                .blockDimZ = 1,
+                .sharedMemBytes = 0,
+                .kernelParams = scatter_args,
+            };
+            scatter_params.func = group.scatter;
+            checkError(cuGraphAddKernelNode(
+                &scatter_node, graph, &center_node, 1, &scatter_params));
+            previous = scatter_node;
+        }
+
+        int normalize_width = group.width;
+        int normalize_height = group.height;
+        int normalize_stride = stride;
+        int normalize_planes = group.planes;
+        int normalize_outputs = chunk_size;
+        CUdeviceptr group_accum = d_accum + group.accum_row * stride * sizeof(float);
+        void * normalize_args[] {
+            &group_accum, &normalize_width, &normalize_height, &normalize_stride,
+            &normalize_planes, &normalize_outputs
+        };
+        CUgraphNode normalize_node;
+        CUDA_KERNEL_NODE_PARAMS normalize_params {
+            .func = group.normalize,
+            .gridDimX = static_cast<unsigned int>((group.width + 255) / 256),
+            .gridDimY = static_cast<unsigned int>(group.height),
+            .gridDimZ = static_cast<unsigned int>(chunk_size * group.planes),
+            .blockDimX = 256,
+            .blockDimY = 1,
+            .blockDimZ = 1,
+            .sharedMemBytes = 0,
+            .kernelParams = normalize_args,
+        };
+        checkError(cuGraphAddKernelNode(
+            &normalize_node, graph, &previous, 1, &normalize_params));
+        previous_group = normalize_node;
+
+        CUgraphNode dependencies[] { normalize_node };
+        for (int output = 0; output < chunk_size; ++output) {
+            for (int plane = 0; plane < group.planes; ++plane) {
+                const size_t row = group.accum_row +
+                    (static_cast<size_t>(output) * group.planes + plane) * 2 * group.height;
+                CUDA_MEMCPY3D output_params {
+                    .srcMemoryType = CU_MEMORYTYPE_DEVICE,
+                    .srcDevice = d_accum + row * stride * sizeof(float),
+                    .srcPitch = pitch,
+                    .dstMemoryType = CU_MEMORYTYPE_HOST,
+                    .dstHost = reinterpret_cast<char *>(h_output) + row * stride * sizeof(float),
+                    .dstPitch = pitch,
+                    .WidthInBytes = static_cast<size_t>(group.width) * sizeof(float),
+                    .Height = static_cast<size_t>(group.height),
+                    .Depth = 1,
+                };
+                CUgraphNode output_copy;
+                checkError(cuGraphAddMemcpyNode(
+                    &output_copy, graph, dependencies, 1, &output_params, context));
+            }
+        }
     }
 
     CUgraphExec graphexec;
@@ -1238,7 +1466,7 @@ static void BM3DCreateImpl(
                         sigma[0], block_step[0], bm_range[0],
                         radius, ps_num[0], ps_range[0],
                         true, sigma[1], sigma[2],
-                        final_, fused,
+                        final_, fused, false,
                         d->bm_error_s[0],
                         d->transform_2d_s[0], d->transform_1d_s[0],
                         extractor,
@@ -1290,7 +1518,7 @@ static void BM3DCreateImpl(
                                 plane_width, plane_height, d_stride,
                                 sigma[plane], block_step[plane], bm_range[plane],
                                 radius, ps_num[plane], ps_range[plane],
-                                false, 0.0f, 0.0f, final_, fused,
+                                false, 0.0f, 0.0f, final_, fused, false,
                                 d->bm_error_s[plane],
                                 d->transform_2d_s[plane], d->transform_1d_s[plane],
                                 extractor,
@@ -1358,6 +1586,524 @@ static void VS_CC BM3DCreate(
     VSCore *core, const VSAPI *vsapi
 ) noexcept {
     BM3DCreateImpl(in, out, userData, core, vsapi, false);
+}
+
+struct RollingResource {
+    Resource<CUdeviceptr, cuMemFree> d_src;
+    Resource<CUdeviceptr, cuMemFree> d_scratch;
+    Resource<CUdeviceptr, cuMemFree> d_accum;
+    Resource<float *, cuMemFreeHost> h_src;
+    Resource<float *, cuMemFreeHost> h_output;
+    Resource<CUdeviceptr, cuMemFree> d_params;
+    Resource<int *, cuMemFreeHost> h_params;
+    Resource<CUstream, cuStreamDestroy> stream;
+    Resource<CUgraphExec, cuGraphExecDestroy> graphexec;
+};
+
+struct RollingData {
+    VSNodeRef * node {};
+    VSNodeRef * ref_node {};
+    const VSVideoInfo * vi {};
+    int radius {};
+    int chunk_size {};
+    int d_pitch {};
+    CUdevice device {};
+    CUcontext context {};
+    std::array<Resource<CUmodule, cuModuleUnload>, 3> modules;
+    bool chroma {};
+    bool final_ {};
+    bool process[3] {};
+    std::string bm_error_s[3];
+    std::string transform_2d_s[3];
+    std::string transform_1d_s[3];
+    size_t source_rows {};
+    size_t output_rows {};
+    size_t output_plane_rows[3] {};
+    size_t output_step_rows[3] {};
+    RollingResource resource;
+    std::mutex resource_lock;
+    mutable std::shared_mutex cache_lock;
+    int cached_start { -1 };
+    std::vector<const VSFrameRef *> cached_frames;
+};
+
+struct RollingRequest { int chunk_start; };
+
+static bool checked_mul(size_t lhs, size_t rhs, size_t & result) noexcept {
+    if (lhs && rhs > std::numeric_limits<size_t>::max() / lhs) return false;
+    result = lhs * rhs;
+    return true;
+}
+
+static bool checked_add(size_t lhs, size_t rhs, size_t & result) noexcept {
+    if (rhs > std::numeric_limits<size_t>::max() - lhs) return false;
+    result = lhs + rhs;
+    return true;
+}
+
+static void VS_CC RollingInit(
+    VSMap *, VSMap *, void **instanceData, VSNode *node,
+    VSCore *, const VSAPI *vsapi
+) noexcept {
+    auto d = static_cast<RollingData *>(*instanceData);
+    vsapi->setVideoInfo(d->vi, 1, node);
+}
+
+static const VSFrameRef * rolling_cache_get(
+    const RollingData * d, int n, const VSAPI *vsapi
+) noexcept {
+    std::shared_lock lock { d->cache_lock };
+    const int offset = n - d->cached_start;
+    if (offset < 0 || offset >= std::ssize(d->cached_frames)) return nullptr;
+    return vsapi->cloneFrameRef(d->cached_frames[offset]);
+}
+
+static const VSFrameRef *VS_CC RollingGetFrame(
+    int n, int activationReason, void **instanceData, void **frameData,
+    VSFrameContext *frameCtx, VSCore *core, const VSAPI *vsapi
+) noexcept {
+    auto d = static_cast<RollingData *>(*instanceData);
+    if (activationReason == arInitial) {
+        const int chunk_start = n / d->chunk_size * d->chunk_size;
+        *frameData = new RollingRequest { chunk_start };
+        if (const VSFrameRef * cached = rolling_cache_get(d, n, vsapi)) {
+            delete static_cast<RollingRequest *>(*frameData);
+            *frameData = nullptr;
+            return cached;
+        }
+        const int64_t first = std::max<int64_t>(
+            static_cast<int64_t>(chunk_start) - 2LL * d->radius, 0);
+        const int64_t last = std::min<int64_t>(
+            static_cast<int64_t>(chunk_start) + d->chunk_size - 1 + 2LL * d->radius,
+            d->vi->numFrames - 1);
+        for (int64_t frame = first; frame <= last; ++frame) {
+            vsapi->requestFrameFilter(static_cast<int>(frame), d->node, frameCtx);
+            if (d->final_) vsapi->requestFrameFilter(
+                static_cast<int>(frame), d->ref_node, frameCtx);
+        }
+        return nullptr;
+    }
+    if (activationReason == arError) {
+        delete static_cast<RollingRequest *>(*frameData);
+        *frameData = nullptr;
+        return nullptr;
+    }
+    if (activationReason != arAllFramesReady) return nullptr;
+
+    std::unique_ptr<RollingRequest> request {
+        static_cast<RollingRequest *>(*frameData) };
+    *frameData = nullptr;
+    if (const VSFrameRef * cached = rolling_cache_get(d, n, vsapi)) return cached;
+
+    std::unique_lock resource_guard { d->resource_lock };
+    if (const VSFrameRef * cached = rolling_cache_get(d, n, vsapi)) return cached;
+    const auto set_error = [&](const std::string & message) {
+        vsapi->setFilterError(("BM3Dv2 rolling: " + message).c_str(), frameCtx);
+        return static_cast<const VSFrameRef *>(nullptr);
+    };
+    if (CUresult result = cuCtxPushCurrent(d->context); result != CUDA_SUCCESS) {
+        const char * error_string;
+        cuGetErrorString(result, &error_string);
+        return set_error("'cuCtxPushCurrent(d->context)' failed: "s + error_string);
+    }
+    struct ContextGuard {
+        ~ContextGuard() noexcept { cuCtxPopCurrent(nullptr); }
+    } context_guard;
+    const int chunk_start = request->chunk_start;
+    const int valid_outputs = std::min(d->chunk_size, d->vi->numFrames - chunk_start);
+    const int logical_first = chunk_start - 2 * d->radius;
+    const int logical_source_width = d->chunk_size + 4 * d->radius;
+    const int centers = d->chunk_size + 2 * d->radius;
+    const int first_frame = std::max(logical_first, 0);
+    const int last_frame = std::min(
+        chunk_start + d->chunk_size - 1 + 2 * d->radius,
+        d->vi->numFrames - 1);
+    const int unique_frames = last_frame - first_frame + 1;
+    using freeFrame_t = decltype(vsapi->freeFrame);
+    using FramePtr = std::unique_ptr<const VSFrameRef, const freeFrame_t &>;
+    std::vector<FramePtr> source_frames;
+    std::vector<FramePtr> reference_frames;
+    source_frames.reserve(unique_frames);
+    reference_frames.reserve(d->final_ ? unique_frames : 0);
+    for (int frame = first_frame; frame <= last_frame; ++frame) {
+        source_frames.emplace_back(vsapi->getFrameFilter(frame, d->node, frameCtx), vsapi->freeFrame);
+        if (d->final_) reference_frames.emplace_back(
+            vsapi->getFrameFilter(frame, d->ref_node, frameCtx), vsapi->freeFrame);
+    }
+
+    RollingResource & resource = d->resource;
+    const int d_stride = d->d_pitch / sizeof(float);
+    auto stage_plane = [&](float * & dst, const std::vector<FramePtr> & frames,
+                           int plane, int plane_height) {
+        const int plane_width = vsapi->getFrameWidth(frames.front().get(), plane);
+        const int source_pitch = vsapi->getStride(frames.front().get(), plane);
+        for (int logical = 0; logical < logical_source_width; ++logical) {
+            const int frame = std::clamp(logical_first + logical, 0, d->vi->numFrames - 1);
+            const VSFrameRef * source = frames[frame - first_frame].get();
+            vs_bitblt(dst, d->d_pitch, vsapi->getReadPtr(source, plane), source_pitch,
+                plane_width * sizeof(float), plane_height);
+            dst += static_cast<size_t>(d_stride) * plane_height;
+        }
+    };
+    float * h_dst = resource.h_src;
+    if (d->chroma) {
+        if (d->final_) for (int plane = 0; plane < 3; ++plane)
+            stage_plane(h_dst, reference_frames, plane, d->vi->height);
+        for (int plane = 0; plane < 3; ++plane)
+            stage_plane(h_dst, source_frames, plane, d->vi->height);
+    } else {
+        for (int plane = 0; plane < d->vi->format->numPlanes; ++plane) {
+            if (!d->process[plane]) continue;
+            const int plane_height = plane ? d->vi->height >> d->vi->format->subSamplingH : d->vi->height;
+            if (d->final_) stage_plane(h_dst, reference_frames, plane, plane_height);
+            stage_plane(h_dst, source_frames, plane, plane_height);
+        }
+    }
+    resource.h_params.data[0] = logical_source_width;
+    for (int center = 0; center < centers; ++center) {
+        const int frame = std::clamp(chunk_start - d->radius + center, 0, d->vi->numFrames - 1);
+        resource.h_params.data[1 + center] = frame - logical_first;
+    }
+    checkError(cuGraphLaunch(resource.graphexec, resource.stream));
+    checkError(cuStreamSynchronize(resource.stream));
+
+    std::vector<const VSFrameRef *> new_cache;
+    new_cache.reserve(valid_outputs);
+    for (int output = 0; output < valid_outputs; ++output) {
+        const VSFrameRef * source = source_frames[chunk_start + output - first_frame].get();
+        const VSFrameRef * plane_sources[] {
+            d->process[0] ? nullptr : source,
+            d->process[1] ? nullptr : source,
+            d->process[2] ? nullptr : source };
+        constexpr int planes[] { 0, 1, 2 };
+        VSFrameRef * destination = vsapi->newVideoFrame2(
+            d->vi->format, d->vi->width, d->vi->height,
+            plane_sources, planes, source, core);
+        for (int plane = 0; plane < d->vi->format->numPlanes; ++plane) {
+            if (!d->process[plane]) continue;
+            const int plane_width = vsapi->getFrameWidth(source, plane);
+            const int plane_height = vsapi->getFrameHeight(source, plane);
+            const size_t row = d->output_plane_rows[plane] +
+                static_cast<size_t>(output) * d->output_step_rows[plane];
+            const float * h_source = resource.h_output.data + row * d_stride;
+            vs_bitblt(vsapi->getWritePtr(destination, plane),
+                vsapi->getStride(destination, plane), h_source, d->d_pitch,
+                plane_width * sizeof(float), plane_height);
+        }
+        new_cache.push_back(destination);
+    }
+    std::vector<const VSFrameRef *> old_cache;
+    {
+        std::unique_lock lock { d->cache_lock };
+        old_cache = std::move(d->cached_frames);
+        d->cached_frames = std::move(new_cache);
+        d->cached_start = chunk_start;
+    }
+    for (const VSFrameRef * frame : old_cache) vsapi->freeFrame(frame);
+    return rolling_cache_get(d, n, vsapi);
+}
+
+static void VS_CC RollingFree(void *instanceData, VSCore *, const VSAPI *vsapi) noexcept {
+    auto d = static_cast<RollingData *>(instanceData);
+    std::vector<const VSFrameRef *> cached;
+    { std::unique_lock lock { d->cache_lock }; cached = std::move(d->cached_frames); }
+    for (const VSFrameRef * frame : cached) vsapi->freeFrame(frame);
+    vsapi->freeNode(d->node);
+    vsapi->freeNode(d->ref_node);
+    const CUdevice device = d->device;
+    cuCtxPushCurrent(d->context);
+    delete d;
+    cuCtxPopCurrent(nullptr);
+    cuDevicePrimaryCtxRelease(device);
+}
+
+static void RollingCreate(
+    const VSMap *in, VSMap *out, int chunk_size,
+    VSCore *core, const VSAPI *vsapi
+) noexcept {
+    auto d = std::make_unique<RollingData>();
+    bool primary_context_retained = false;
+    bool context_pushed = false;
+    const auto set_error = [&](const std::string & message) {
+        vsapi->setError(out, ("BM3Dv2 rolling: " + message).c_str());
+        if (d->node) vsapi->freeNode(d->node);
+        if (d->ref_node) vsapi->freeNode(d->ref_node);
+        d->node = nullptr;
+        d->ref_node = nullptr;
+        const CUdevice retained_device = d->device;
+        // Resource destructors need the owning CUDA context to be current.
+        d.reset();
+        if (context_pushed) {
+            cuCtxPopCurrent(nullptr);
+            context_pushed = false;
+        }
+        if (primary_context_retained) {
+            cuDevicePrimaryCtxRelease(retained_device);
+            primary_context_retained = false;
+        }
+    };
+    d->node = vsapi->propGetNode(in, "clip", 0, nullptr);
+    d->vi = vsapi->getVideoInfo(d->node);
+    const int width = d->vi->width;
+    const int height = d->vi->height;
+    if (!isConstantFormat(d->vi) || d->vi->format->sampleType == stInteger ||
+        d->vi->format->bitsPerSample != 32) {
+        return set_error("only constant format 32bit float input supported");
+    }
+    int error;
+    d->ref_node = vsapi->propGetNode(in, "ref", 0, &error);
+    if (error) {
+        d->final_ = false;
+    } else {
+        const VSVideoInfo * ref_vi = vsapi->getVideoInfo(d->ref_node);
+        if (ref_vi->format->id != d->vi->format->id || ref_vi->width != width ||
+            ref_vi->height != height || ref_vi->numFrames != d->vi->numFrames) {
+            return set_error("\"ref\" must match clip format, dimensions, and frame count");
+        }
+        d->final_ = true;
+    }
+    float sigma[3];
+    for (int plane = 0; plane < 3; ++plane) {
+        sigma[plane] = static_cast<float>(vsapi->propGetFloat(in, "sigma", plane, &error));
+        if (error) sigma[plane] = plane ? sigma[plane - 1] : 3.0f;
+        else if (sigma[plane] < 0.0f) return set_error("\"sigma\" must be non-negative");
+        d->process[plane] = sigma[plane] >= std::numeric_limits<float>::epsilon();
+        sigma[plane] *= (3.0f / 4.0f) / 255.0f * 64.0f * (d->final_ ? 1.0f : 2.7f);
+    }
+    for (int plane = 0; plane < 3; ++plane) {
+        auto value = vsapi->propGetData(in, "bm_error_s", plane, &error);
+        d->bm_error_s[plane] = error ? (plane ? d->bm_error_s[plane - 1] : "ssd") :
+            std::string { value ? value : "" };
+        std::transform(d->bm_error_s[plane].begin(), d->bm_error_s[plane].end(),
+            d->bm_error_s[plane].begin(), [](unsigned char c) { return std::tolower(c); });
+        if (d->bm_error_s[plane] == "ssd/norm") d->bm_error_s[plane] = "ssd_norm";
+        if (d->bm_error_s[plane] != "ssd" && d->bm_error_s[plane] != "sad" &&
+            d->bm_error_s[plane] != "zssd" && d->bm_error_s[plane] != "zsad" &&
+            d->bm_error_s[plane] != "ssd_norm") return set_error("invalid 'bm_error_s': " + d->bm_error_s[plane]);
+        value = vsapi->propGetData(in, "transform_2d_s", plane, &error);
+        d->transform_2d_s[plane] = error ? (plane ? d->transform_2d_s[plane - 1] : "dct") :
+            std::string { value ? value : "" };
+        std::transform(d->transform_2d_s[plane].begin(), d->transform_2d_s[plane].end(),
+            d->transform_2d_s[plane].begin(), [](unsigned char c) { return std::tolower(c); });
+        if (d->transform_2d_s[plane] == "bior1.5") d->transform_2d_s[plane] = "bior1_5";
+        if (d->transform_2d_s[plane] != "dct" && d->transform_2d_s[plane] != "haar" &&
+            d->transform_2d_s[plane] != "wht" && d->transform_2d_s[plane] != "bior1_5") return set_error("invalid 'transform_2d_s': " + d->transform_2d_s[plane]);
+        value = vsapi->propGetData(in, "transform_1d_s", plane, &error);
+        d->transform_1d_s[plane] = error ? (plane ? d->transform_1d_s[plane - 1] : "dct") :
+            std::string { value ? value : "" };
+        std::transform(d->transform_1d_s[plane].begin(), d->transform_1d_s[plane].end(),
+            d->transform_1d_s[plane].begin(), [](unsigned char c) { return std::tolower(c); });
+        if (d->transform_1d_s[plane] == "bior1.5") d->transform_1d_s[plane] = "bior1_5";
+        if (d->transform_1d_s[plane] != "dct" && d->transform_1d_s[plane] != "haar" &&
+            d->transform_1d_s[plane] != "wht" && d->transform_1d_s[plane] != "bior1_5") return set_error("invalid 'transform_1d_s': " + d->transform_1d_s[plane]);
+    }
+    int block_step[3], bm_range[3], ps_num[3], ps_range[3];
+    for (int plane = 0; plane < 3; ++plane) {
+        block_step[plane] = int64ToIntS(vsapi->propGetInt(in, "block_step", plane, &error));
+        if (error) block_step[plane] = plane ? block_step[plane - 1] : 8;
+        else if (block_step[plane] <= 0 || block_step[plane] > 8) return set_error("\"block_step\" must be in range [1, 8]");
+        bm_range[plane] = int64ToIntS(vsapi->propGetInt(in, "bm_range", plane, &error));
+        if (error) bm_range[plane] = plane ? bm_range[plane - 1] : 9;
+        else if (bm_range[plane] <= 0) return set_error("\"bm_range\" must be positive");
+        ps_num[plane] = int64ToIntS(vsapi->propGetInt(in, "ps_num", plane, &error));
+        if (error) ps_num[plane] = plane ? ps_num[plane - 1] : 2;
+        else if (ps_num[plane] <= 0 || ps_num[plane] > 8) return set_error("\"ps_num\" must be in range [1, 8]");
+        ps_range[plane] = int64ToIntS(vsapi->propGetInt(in, "ps_range", plane, &error));
+        if (error) ps_range[plane] = plane ? ps_range[plane - 1] : 4;
+        else if (ps_range[plane] <= 0) return set_error("\"ps_range\" must be positive");
+    }
+    d->radius = int64ToIntS(vsapi->propGetInt(in, "radius", 0, &error));
+    if (error) d->radius = 0;
+    if (d->radius <= 0) return set_error("\"radius\" must be positive");
+    if (d->radius > (std::numeric_limits<int>::max() - chunk_size) / 4)
+        return set_error("\"radius\" is too large for rolling temporal processing");
+    d->chunk_size = chunk_size;
+    d->chroma = !!vsapi->propGetInt(in, "chroma", 0, &error);
+    if (error) d->chroma = false;
+    if (d->chroma && d->vi->format->id != pfYUV444PS)
+        return set_error("clip format must be YUV444 when \"chroma\" is true");
+    const int device_id = [&] {
+        const int value = int64ToIntS(vsapi->propGetInt(in, "device_id", 0, &error));
+        return error ? 0 : value;
+    }();
+    checkError(cuInit(0));
+    int device_count;
+    checkError(cuDeviceGetCount(&device_count));
+    if (device_id < 0 || device_id >= device_count)
+        return set_error("invalid device ID (" + std::to_string(device_id) + ")");
+    checkError(cuDeviceGet(&d->device, device_id));
+    checkError(cuDevicePrimaryCtxRetain(&d->context, d->device));
+    primary_context_retained = true;
+    checkError(cuCtxPushCurrent(d->context));
+    context_pushed = true;
+    const float extractor = [&] {
+        const int exponent = int64ToIntS(vsapi->propGetInt(in, "extractor_exp", 0, &error));
+        return error ? 0.0f : (exponent ? std::ldexp(1.0f, exponent) : 0.0f);
+    }();
+    std::vector<RollingGroup> groups;
+    const int source_width = chunk_size + 4 * d->radius;
+    const int temporal_width = 2 * d->radius + 1;
+    const int centers = chunk_size + 2 * d->radius;
+    const int clips = d->final_ ? 2 : 1;
+    const int graph_planes = d->chroma ? 3 : 1;
+    const int max_width = d->process[0] ? width : width >> d->vi->format->subSamplingW;
+    const int max_height = d->process[0] ? height : height >> d->vi->format->subSamplingH;
+    int process_mask = 0;
+    for (int plane = 0; plane < d->vi->format->numPlanes; ++plane) {
+        process_mask |= static_cast<int>(d->process[plane]) << plane;
+    }
+    if (max_width > std::numeric_limits<int>::max() - 255 || max_height > 65535)
+        return set_error("clip dimensions exceed CUDA grid limits");
+    size_t temporal_stride = 0;
+    size_t source_offset = 0;
+    size_t scratch_offset = 0;
+    if (!checked_mul(static_cast<size_t>(max_width), max_height, temporal_stride) ||
+        !checked_mul(temporal_stride, source_width, source_offset) ||
+        !checked_mul(temporal_stride, static_cast<size_t>(temporal_width) * 2, scratch_offset) ||
+        !checked_mul(source_offset, graph_planes, source_offset) ||
+        !checked_mul(scratch_offset, graph_planes, scratch_offset) ||
+        source_offset > std::numeric_limits<int>::max() ||
+        scratch_offset > std::numeric_limits<int>::max()) {
+        return set_error("clip dimensions exceed CUDA indexing limits");
+    }
+    size_t source_rows = 0, output_rows = 0;
+    if (d->chroma) {
+        size_t plane_rows = 0;
+        if (!checked_mul(static_cast<size_t>(source_width), height, plane_rows) ||
+            !checked_mul(plane_rows, static_cast<size_t>(clips) * 3, source_rows) ||
+            !checked_mul(static_cast<size_t>(chunk_size) * 6, height, output_rows)) {
+            return set_error("rolling buffer size overflow");
+        }
+        groups.push_back({0, 3, width, height, 0, 0, {}, {}, {},
+            sigma[0], sigma[1], sigma[2], block_step[0], bm_range[0], ps_num[0], ps_range[0]});
+        for (int plane = 0; plane < 3; ++plane) {
+            d->output_plane_rows[plane] = static_cast<size_t>(plane) * 2 * height;
+            d->output_step_rows[plane] = static_cast<size_t>(6) * height;
+        }
+    } else {
+        for (int plane = 0; plane < d->vi->format->numPlanes; ++plane) {
+            if (!d->process[plane]) continue;
+            const int plane_width = plane ? width >> d->vi->format->subSamplingW : width;
+            const int plane_height = plane ? height >> d->vi->format->subSamplingH : height;
+            groups.push_back({plane, 1, plane_width, plane_height, source_rows,
+                output_rows, {}, {}, {}, sigma[plane], 0.0f, 0.0f,
+                block_step[plane], bm_range[plane], ps_num[plane], ps_range[plane]});
+            size_t plane_source_rows = 0;
+            size_t plane_output_rows = 0;
+            size_t updated = 0;
+            if (!checked_mul(static_cast<size_t>(clips) * source_width,
+                    plane_height, plane_source_rows) ||
+                !checked_add(source_rows, plane_source_rows, updated)) {
+                return set_error("rolling buffer size overflow");
+            }
+            source_rows = updated;
+            d->output_plane_rows[plane] = output_rows;
+            d->output_step_rows[plane] = static_cast<size_t>(2) * plane_height;
+            if (!checked_mul(static_cast<size_t>(chunk_size) * 2,
+                    plane_height, plane_output_rows) ||
+                !checked_add(output_rows, plane_output_rows, updated)) {
+                return set_error("rolling buffer size overflow");
+            }
+            output_rows = updated;
+        }
+    }
+    d->source_rows = source_rows;
+    d->output_rows = output_rows;
+    const size_t pitch_min = static_cast<size_t>(max_width) * sizeof(float);
+    size_t pitch;
+    checkError(cuMemAllocPitch(&d->resource.d_src.data, &pitch, pitch_min, source_rows, 4));
+    if (pitch > static_cast<size_t>(std::numeric_limits<int>::max()) || pitch % sizeof(float))
+        return set_error("device pitch exceeds the supported range");
+    d->d_pitch = static_cast<int>(pitch);
+    const size_t d_stride = pitch / sizeof(float);
+    if (!checked_mul(d_stride, max_height, temporal_stride) ||
+        !checked_mul(temporal_stride, source_width, source_offset) ||
+        !checked_mul(temporal_stride, static_cast<size_t>(temporal_width) * 2, scratch_offset) ||
+        !checked_mul(source_offset, graph_planes, source_offset) ||
+        !checked_mul(scratch_offset, graph_planes, scratch_offset) ||
+        source_offset > std::numeric_limits<int>::max() ||
+        scratch_offset > std::numeric_limits<int>::max()) {
+        return set_error("device pitch exceeds CUDA indexing limits");
+    }
+    const size_t scratch_rows = static_cast<size_t>(graph_planes) * temporal_width * 2 * max_height;
+    size_t scratch_bytes = 0, source_bytes = 0, output_bytes = 0;
+    if (!checked_mul(scratch_rows, pitch, scratch_bytes) ||
+        !checked_mul(source_rows, pitch, source_bytes) ||
+        !checked_mul(output_rows, pitch, output_bytes)) {
+        return set_error("rolling allocation size overflow");
+    }
+    checkError(cuMemAlloc(&d->resource.d_scratch.data, scratch_bytes));
+    checkError(cuMemAlloc(&d->resource.d_accum.data, output_bytes));
+    checkError(cuMemAllocHost(reinterpret_cast<void **>(&d->resource.h_src.data), source_bytes));
+    checkError(cuMemAllocHost(reinterpret_cast<void **>(&d->resource.h_output.data), output_bytes));
+    const size_t params_count = 1 + static_cast<size_t>(centers);
+    size_t params_bytes = 0;
+    if (!checked_mul(params_count, sizeof(int), params_bytes))
+        return set_error("rolling parameter size overflow");
+    checkError(cuMemAlloc(&d->resource.d_params.data, params_bytes));
+    checkError(cuMemAllocHost(reinterpret_cast<void **>(&d->resource.h_params.data), params_bytes));
+    checkError(cuStreamCreate(&d->resource.stream.data, CU_STREAM_NON_BLOCKING));
+
+    for (auto & group : groups) {
+        const int plane = group.first_plane;
+        const auto result = compile(
+            group.width, group.height, d->d_pitch / sizeof(float),
+            group.sigma, group.block_step, group.bm_range,
+            d->radius, group.ps_num, group.ps_range,
+            d->chroma, d->chroma ? sigma[1] : 0.0f, d->chroma ? sigma[2] : 0.0f,
+            d->final_, false, true,
+            d->bm_error_s[plane], d->transform_2d_s[plane], d->transform_1d_s[plane],
+            extractor, d->device);
+        if (std::holds_alternative<std::string>(result)) return set_error(std::get<std::string>(result));
+        d->modules[plane] = std::get<CUmodule>(result);
+        checkError(cuModuleGetFunction(&group.bm3d, d->modules[plane], "bm3d"));
+        checkError(cuModuleGetFunction(&group.scatter, d->modules[plane], "rolling_scatter"));
+        checkError(cuModuleGetFunction(&group.normalize, d->modules[plane], "rolling_normalize"));
+    }
+    const auto graph = get_rolling_graphexec(
+        d->resource.d_accum, d->resource.d_scratch, d->resource.d_src,
+        d->resource.h_src, d->resource.h_output, d->resource.d_params,
+        d->resource.h_params, width, height, d->d_pitch / sizeof(float),
+        block_step, d->radius, chunk_size,
+        process_mask,
+        d->vi->format->numPlanes, d->vi->format->subSamplingW,
+        d->vi->format->subSamplingH, d->chroma, d->final_, extractor, d->context, groups);
+    if (std::holds_alternative<std::string>(graph)) return set_error(std::get<std::string>(graph));
+    d->resource.graphexec = std::get<CUgraphExec>(graph);
+    cuCtxPopCurrent(nullptr);
+    context_pushed = false;
+    primary_context_retained = false;
+    vsapi->createFilter(in, out, "BM3Dv2 rolling", RollingInit, RollingGetFrame,
+        RollingFree, fmParallelRequests, 0, d.release(), core);
+}
+
+static VSMap * copy_bm3d_args(const VSMap *in, const VSAPI *vsapi) noexcept {
+    VSMap *result = vsapi->createMap();
+    for (int key_index = 0; key_index < vsapi->propNumKeys(in); ++key_index) {
+        const char *key = vsapi->propGetKey(in, key_index);
+        if (std::string_view { key } == "temporal_mode" ||
+            std::string_view { key } == "rolling_chunk") continue;
+        const int elements = vsapi->propNumElements(in, key);
+        const int type = vsapi->propGetType(in, key);
+        for (int index = 0; index < elements; ++index) {
+            if (type == ptInt) {
+                vsapi->propSetInt(result, key,
+                    vsapi->propGetInt(in, key, index, nullptr), paAppend);
+            } else if (type == ptFloat) {
+                vsapi->propSetFloat(result, key,
+                    vsapi->propGetFloat(in, key, index, nullptr), paAppend);
+            } else if (type == ptNode) {
+                auto node = vsapi->propGetNode(in, key, index, nullptr);
+                vsapi->propSetNode(result, key, node, paAppend);
+                vsapi->freeNode(node);
+            } else if (type == ptData) {
+                const char *data = vsapi->propGetData(in, key, index, nullptr);
+                vsapi->propSetData(result, key, data,
+                    vsapi->propGetDataSize(in, key, index, nullptr), paAppend);
+            }
+        }
+    }
+    return result;
 }
 
 struct VAggregateData {
@@ -1579,6 +2325,32 @@ static void VS_CC BM3Dv2Create(
     VSCore *core, const VSAPI *vsapi
 ) {
 
+    int error;
+    std::string temporal_mode { "fused" };
+    if (vsapi->propNumElements(in, "temporal_mode") >= 0) {
+        const char * value = vsapi->propGetData(in, "temporal_mode", 0, &error);
+        const int size = vsapi->propGetDataSize(in, "temporal_mode", 0, &error);
+        if (error) { vsapi->setError(out, "BM3Dv2: \"temporal_mode\" must be a string"); return; }
+        temporal_mode.assign(value, size);
+    }
+    if (temporal_mode != "fused" && temporal_mode != "legacy" && temporal_mode != "rolling") {
+        vsapi->setError(out, "BM3Dv2: \"temporal_mode\" must be one of fused, legacy, or rolling");
+        return;
+    }
+    const bool chunk_supplied = vsapi->propNumElements(in, "rolling_chunk") >= 0;
+    if (chunk_supplied && temporal_mode != "rolling") {
+        vsapi->setError(out, "BM3Dv2: \"rolling_chunk\" is valid only when temporal_mode is rolling");
+        return;
+    }
+    int rolling_chunk = 16;
+    if (chunk_supplied) {
+        rolling_chunk = int64ToIntS(vsapi->propGetInt(in, "rolling_chunk", 0, &error));
+        if (error || rolling_chunk < 1 || rolling_chunk > 64) {
+            vsapi->setError(out, "BM3Dv2: \"rolling_chunk\" must be in range [1, 64]");
+            return;
+        }
+    }
+
     std::array<bool, 3> process;
     process.fill(true);
 
@@ -1598,6 +2370,15 @@ static void VS_CC BM3Dv2Create(
     bool skip = true;
     auto src = vsapi->propGetNode(in, "clip", 0, nullptr);
     auto src_vi = vsapi->getVideoInfo(src);
+    const int source_planes = src_vi->format->numPlanes;
+    error = 0;
+    int radius = int64ToIntS(vsapi->propGetInt(in, "radius", 0, &error));
+    if (error) radius = 0;
+    if (temporal_mode == "rolling" && radius <= 0) {
+        vsapi->freeNode(src);
+        vsapi->setError(out, "BM3Dv2: rolling temporal mode requires radius greater than zero");
+        return;
+    }
     for (int i = 0; i < src_vi->format->numPlanes; ++i) {
         skip &= !process[i];
     }
@@ -1607,19 +2388,38 @@ static void VS_CC BM3Dv2Create(
         return ;
     }
 
-    int error;
-    int radius = int64ToIntS(vsapi->propGetInt(in, "radius", 0, &error));
-    if (error) {
-        radius = 0;
-    }
     if (radius > 0) {
         vsapi->freeNode(src);
-        BM3DCreateImpl(in, out, userData, core, vsapi, true);
+        if (temporal_mode == "fused") {
+            BM3DCreateImpl(in, out, userData, core, vsapi, true);
+        } else if (temporal_mode == "rolling") {
+            RollingCreate(in, out, rolling_chunk, core, vsapi);
+        } else {
+            auto plugin = vsapi->getPluginById(PLUGIN_ID, core);
+            auto map = copy_bm3d_args(in, vsapi);
+            auto bm_map = vsapi->invoke(plugin, "BM3D", map);
+            vsapi->freeMap(map);
+            if (const char * invoke_error = vsapi->getError(bm_map)) { vsapi->setError(out, invoke_error); vsapi->freeMap(bm_map); return; }
+            auto original = vsapi->propGetNode(in, "clip", 0, nullptr);
+            vsapi->propSetNode(bm_map, "src", original, paReplace);
+            vsapi->freeNode(original);
+            for (int plane = 0; plane < source_planes; ++plane)
+                if (process[plane]) vsapi->propSetInt(bm_map, "planes", plane, paAppend);
+            auto aggregate = vsapi->invoke(plugin, "VAggregate", bm_map);
+            vsapi->freeMap(bm_map);
+            if (const char * invoke_error = vsapi->getError(aggregate)) { vsapi->setError(out, invoke_error); vsapi->freeMap(aggregate); return; }
+            auto node = vsapi->propGetNode(aggregate, "clip", 0, nullptr);
+            vsapi->freeMap(aggregate);
+            vsapi->propSetNode(out, "clip", node, paReplace);
+            vsapi->freeNode(node);
+        }
         return;
     }
 
     auto plugin = vsapi->getPluginById(PLUGIN_ID, core);
-    auto map = vsapi->invoke(plugin, "BM3D", in);
+    auto bm3d_in = copy_bm3d_args(in, vsapi);
+    auto map = vsapi->invoke(plugin, "BM3D", bm3d_in);
+    vsapi->freeMap(bm3d_in);
     if (auto error = vsapi->getError(map); error) {
         vsapi->setError(out, error);
         vsapi->freeMap(map);
@@ -1640,7 +2440,7 @@ static void VS_CC BM3Dv2Create(
     vsapi->propSetNode(map, "src", src, paReplace);
     vsapi->freeNode(src);
 
-    for (int i = 0; i < 3; ++i) {
+    for (int i = 0; i < source_planes; ++i) {
         if (process[i]) {
             vsapi->propSetInt(map, "planes", i, paAppend);
         }
@@ -1689,6 +2489,27 @@ VS_EXTERNAL_API(void) VapourSynthPluginInit(
         "zero_init:int:opt;"
     };
 
+    constexpr auto bm3dv2_args {
+        "clip:clip;"
+        "ref:clip:opt;"
+        "sigma:float[]:opt;"
+        "block_step:int[]:opt;"
+        "bm_range:int[]:opt;"
+        "radius:int:opt;"
+        "ps_num:int[]:opt;"
+        "ps_range:int[]:opt;"
+        "chroma:int:opt;"
+        "device_id:int:opt;"
+        "fast:int:opt;"
+        "extractor_exp:int:opt;"
+        "bm_error_s:data[]:opt;"
+        "transform_2d_s:data[]:opt;"
+        "transform_1d_s:data[]:opt;"
+        "zero_init:int:opt;"
+        "temporal_mode:data:opt;"
+        "rolling_chunk:int:opt;"
+    };
+
     registerFunc("BM3D", bm3d_args, BM3DCreate, nullptr, plugin);
 
     registerFunc(
@@ -1698,5 +2519,5 @@ VS_EXTERNAL_API(void) VapourSynthPluginInit(
         "planes:int[];",
         VAggregateCreate, nullptr, plugin);
 
-    registerFunc("BM3Dv2", bm3d_args, BM3Dv2Create, nullptr, plugin);
+    registerFunc("BM3Dv2", bm3dv2_args, BM3Dv2Create, nullptr, plugin);
 }

--- a/source/kernel.cu
+++ b/source/kernel.cu
@@ -65,6 +65,18 @@ std::variant<cudaGraphExec_t, std::string> get_fused_graphexec(
     bool final_, float extractor
 ) noexcept;
 
+std::variant<cudaGraphExec_t, std::string> get_rolling_graphexec(
+    float * d_accum, float * d_scratch, float * d_src,
+    float * h_src, float * h_output,
+    int * d_params, int * h_params,
+    int width, int height, int stride,
+    const float sigma[3], const int block_step[3],
+    const int bm_range[3], const int ps_num[3], const int ps_range[3],
+    int radius, int chunk_size, int process_mask, int video_planes,
+    int subsampling_w, int subsampling_h,
+    bool chroma, bool final_, float extractor
+) noexcept;
+
 static constexpr int smem_stride = 32 + 1;
 
 extern "C" __global__ void temporal_normalize(
@@ -91,6 +103,62 @@ extern "C" __global__ void temporal_normalize(
     }
 
     res[plane * plane_stride + y * stride + x] = __fdiv_rn(weighted_sum, weight);
+}
+
+extern "C" __global__ void rolling_scatter(
+    float * __restrict__ accum,
+    const float * __restrict__ scratch,
+    const int * __restrict__ params,
+    int width, int height, int stride,
+    int num_planes, int radius, int chunk_size, int center
+) {
+    const int x = blockIdx.x * blockDim.x + threadIdx.x;
+    const int y = blockIdx.y;
+    const int plane = blockIdx.z;
+    if (x >= width || y >= height || plane >= num_planes) {
+        return;
+    }
+
+    const int temporal_width = 2 * radius + 1;
+    const int source_center = params[1 + center];
+    const int first_output = max(0, center - 2 * radius);
+    const int last_output = min(chunk_size - 1, center);
+    const size_t image_stride = static_cast<size_t>(height) * stride;
+
+    for (int output = first_output; output <= last_output; ++output) {
+        const int slice = min(max(
+            output + 3 * radius - source_center, 0), temporal_width - 1);
+        const size_t scratch_offset =
+            (static_cast<size_t>(plane) * temporal_width + slice) *
+                2 * image_stride +
+            static_cast<size_t>(y) * stride + x;
+        const size_t accum_offset =
+            (static_cast<size_t>(output) * num_planes + plane) *
+                2 * image_stride +
+            static_cast<size_t>(y) * stride + x;
+
+        accum[accum_offset] += scratch[scratch_offset];
+        accum[accum_offset + image_stride] +=
+            scratch[scratch_offset + image_stride];
+    }
+}
+
+extern "C" __global__ void rolling_normalize(
+    float * __restrict__ accum,
+    int width, int height, int stride,
+    int num_planes, int outputs
+) {
+    const int x = blockIdx.x * blockDim.x + threadIdx.x;
+    const int y = blockIdx.y;
+    const int output_plane = blockIdx.z;
+    if (x >= width || y >= height || output_plane >= outputs * num_planes) {
+        return;
+    }
+
+    const size_t image_stride = static_cast<size_t>(height) * stride;
+    const size_t offset = static_cast<size_t>(output_plane) *
+        2 * image_stride + static_cast<size_t>(y) * stride + x;
+    accum[offset] = __fdiv_rn(accum[offset], accum[offset + image_stride]);
 }
 
 template <auto transform_impl, int stride=256, int howmany=8, int howmany_stride=32>
@@ -402,7 +470,10 @@ static inline float collaborative_wiener(
 }
 
 // BM3D kernel
-template <bool temporal=false, bool chroma=false, bool final_=false, bool fused=false>
+template <
+    bool temporal=false, bool chroma=false, bool final_=false,
+    bool fused=false, bool rolling=false
+>
 __global__
 #if __CUDA_ARCH__ == 750 || __CUDA_ARCH__ == 860
 __launch_bounds__(32, 16)
@@ -423,7 +494,7 @@ static void bm3d(
     float extractor, // used for deteriministic summation
     int source_temporal_width,
     const int * __restrict__ fused_params,
-    int fused_center
+    int graph_center
 ) {
 
     __shared__ float buffer[8 * smem_stride];
@@ -453,10 +524,14 @@ static void bm3d(
     int output_z = -1;
     if constexpr (fused) {
         source_valid_width = fused_params[0];
-        source_center = fused_params[1 + 2 * fused_center];
-        output_z = fused_params[2 + 2 * fused_center];
+        source_center = fused_params[1 + 2 * graph_center];
+        output_z = fused_params[2 + 2 * graph_center];
+    } else if constexpr (rolling) {
+        source_valid_width = fused_params[0];
+        source_center = fused_params[1 + graph_center];
     }
-    int source_plane_stride = (fused ? source_temporal_width : temporal_width) * temporal_stride;
+    int source_plane_stride = ((fused || rolling) ?
+        source_temporal_width : temporal_width) * temporal_stride;
     int result_plane_stride = (fused ? 1 : temporal_width) * temporal_stride;
     int clip_stride = (chroma ? 3 : 1) * source_plane_stride;
 
@@ -572,7 +647,7 @@ static void bm3d(
                 int frame_index8_y = 0;
 
                 int source_index = temporal_index;
-                if constexpr (fused) {
+                if constexpr (fused || rolling) {
                     source_index = min(max(
                         source_center - radius + temporal_index, 0),
                         source_valid_width - 1);
@@ -736,7 +811,7 @@ static void bm3d(
                 if constexpr (temporal) {
                     int tmp_z = __shfl_sync(0xFFFFFFFF, index8_z, i, 8);
                     int source_index = tmp_z;
-                    if constexpr (fused) {
+                    if constexpr (fused || rolling) {
                         source_index = min(max(
                             source_center - radius + tmp_z, 0),
                             source_valid_width - 1);
@@ -764,7 +839,7 @@ static void bm3d(
                 if constexpr (temporal) {
                     int tmp_z = __shfl_sync(0xFFFFFFFF, index8_z, i, 8);
                     int source_index = tmp_z;
-                    if constexpr (fused) {
+                    if constexpr (fused || rolling) {
                         source_index = min(max(
                             source_center - radius + tmp_z, 0),
                             source_valid_width - 1);
@@ -1090,6 +1165,277 @@ std::variant<cudaGraphExec_t, std::string> get_fused_graphexec(
             dependencies, std::extent_v<decltype(dependencies)>,
             &copy_params); result != cudaSuccess) {
             return set_error(result, "cudaGraphAddMemcpyNode(DtoH)");
+        }
+    }
+
+    cudaGraphExec_t graphexec {};
+    if (cudaError_t result = cudaGraphInstantiate(
+        &graphexec, graph.data, nullptr, nullptr, 0); result != cudaSuccess) {
+        return set_error(result, "cudaGraphInstantiate");
+    }
+    return graphexec;
+}
+
+std::variant<cudaGraphExec_t, std::string> get_rolling_graphexec(
+    float * d_accum, float * d_scratch, float * d_src,
+    float * h_src, float * h_output,
+    int * d_params, int * h_params,
+    int width, int height, int stride,
+    const float sigma[3], const int block_step[3],
+    const int bm_range[3], const int ps_num[3], const int ps_range[3],
+    int radius, int chunk_size, int process_mask, int video_planes,
+    int subsampling_w, int subsampling_h,
+    bool chroma, bool final_, float extractor
+) noexcept {
+    const auto set_error = [](cudaError_t result, const char * expression) {
+        return std::string { "'" } + expression + "' failed: " +
+            cudaGetErrorString(result);
+    };
+
+    struct GraphGuard {
+        cudaGraph_t data {};
+
+        ~GraphGuard() noexcept {
+            if (data) {
+                cudaGraphDestroy(data);
+            }
+        }
+    } graph;
+
+    struct Group {
+        int first_plane;
+        int planes;
+        int width;
+        int height;
+        size_t source_row;
+        size_t accum_row;
+    };
+
+    const int temporal_width = 2 * radius + 1;
+    const int source_width = chunk_size + 4 * radius;
+    const int centers = chunk_size + 2 * radius;
+    const int clips = final_ ? 2 : 1;
+    const int copy_width = (process_mask & 1) ?
+        width : width >> subsampling_w;
+    const size_t pitch = static_cast<size_t>(stride) * sizeof(float);
+
+    std::vector<Group> groups;
+    size_t source_rows = 0;
+    size_t accum_rows = 0;
+    if (chroma) {
+        groups.push_back(Group {
+            .first_plane = 0,
+            .planes = 3,
+            .width = width,
+            .height = height,
+            .source_row = 0,
+            .accum_row = 0
+        });
+        source_rows = static_cast<size_t>(clips) * 3 * source_width * height;
+        accum_rows = static_cast<size_t>(chunk_size) * 3 * 2 * height;
+    } else {
+        for (int plane = 0; plane < video_planes; ++plane) {
+            if (!(process_mask & (1 << plane))) {
+                continue;
+            }
+            const int plane_width = plane ? width >> subsampling_w : width;
+            const int plane_height = plane ? height >> subsampling_h : height;
+            groups.push_back(Group {
+                .first_plane = plane,
+                .planes = 1,
+                .width = plane_width,
+                .height = plane_height,
+                .source_row = source_rows,
+                .accum_row = accum_rows
+            });
+            source_rows += static_cast<size_t>(clips) * source_width * plane_height;
+            accum_rows += static_cast<size_t>(chunk_size) * 2 * plane_height;
+        }
+    }
+
+    if (cudaError_t result = cudaGraphCreate(&graph.data, 0); result != cudaSuccess) {
+        return set_error(result, "cudaGraphCreate");
+    }
+
+    cudaGraphNode_t source_copy;
+    {
+        cudaMemcpy3DParms copy_params {};
+        copy_params.srcPtr = make_cudaPitchedPtr(
+            h_src, pitch, copy_width, source_rows);
+        copy_params.dstPtr = make_cudaPitchedPtr(
+            d_src, pitch, copy_width, source_rows);
+        copy_params.extent = make_cudaExtent(
+            static_cast<size_t>(copy_width) * sizeof(float), source_rows, 1);
+        copy_params.kind = cudaMemcpyHostToDevice;
+        if (cudaError_t result = cudaGraphAddMemcpyNode(
+            &source_copy, graph.data, nullptr, 0, &copy_params);
+            result != cudaSuccess) {
+            return set_error(result, "cudaGraphAddMemcpyNode(source HtoD)");
+        }
+    }
+
+    cudaGraphNode_t params_copy;
+    if (cudaError_t result = cudaGraphAddMemcpyNode1D(
+        &params_copy, graph.data, nullptr, 0, d_params, h_params,
+        (1 + static_cast<size_t>(centers)) * sizeof(int),
+        cudaMemcpyHostToDevice); result != cudaSuccess) {
+        return set_error(result, "cudaGraphAddMemcpyNode1D(params)");
+    }
+
+    cudaGraphNode_t accum_clear;
+    {
+        cudaMemsetParams memset_params {};
+        memset_params.dst = d_accum;
+        memset_params.pitch = pitch;
+        memset_params.value = 0;
+        memset_params.elementSize = 4;
+        memset_params.width = copy_width;
+        memset_params.height = accum_rows;
+        if (cudaError_t result = cudaGraphAddMemsetNode(
+            &accum_clear, graph.data, nullptr, 0, &memset_params);
+            result != cudaSuccess) {
+            return set_error(result, "cudaGraphAddMemsetNode(accumulators)");
+        }
+    }
+
+    cudaGraphNode_t previous_group {};
+    for (const Group & group : groups) {
+        cudaGraphNode_t previous = previous_group;
+        for (int center = 0; center < centers; ++center) {
+            cudaGraphNode_t scratch_clear;
+            cudaGraphNode_t initial_dependencies[] {
+                source_copy, params_copy, accum_clear
+            };
+            const cudaGraphNode_t * dependencies = previous ?
+                &previous : initial_dependencies;
+            const size_t dependency_count = previous ? 1 :
+                std::extent_v<decltype(initial_dependencies)>;
+
+            cudaMemsetParams memset_params {};
+            memset_params.dst = d_scratch;
+            memset_params.pitch = pitch;
+            memset_params.value = 0;
+            memset_params.elementSize = 4;
+            memset_params.width = group.width;
+            memset_params.height = static_cast<size_t>(group.planes) *
+                temporal_width * 2 * group.height;
+            if (cudaError_t result = cudaGraphAddMemsetNode(
+                &scratch_clear, graph.data, dependencies, dependency_count,
+                &memset_params); result != cudaSuccess) {
+                return set_error(result, "cudaGraphAddMemsetNode(scratch)");
+            }
+
+            cudaGraphNode_t center_node;
+            float * center_source = d_src + group.source_row * stride;
+            const int plane = group.first_plane;
+            float center_sigma = sigma[plane];
+            float sigma_u = chroma ? sigma[1] : 0.0f;
+            float sigma_v = chroma ? sigma[2] : 0.0f;
+            int center_block_step = block_step[plane];
+            int center_bm_range = bm_range[plane];
+            int center_ps_num = ps_num[plane];
+            int center_ps_range = ps_range[plane];
+            const int * params = d_params;
+
+            void * kernel_args[] {
+                &d_scratch, &center_source,
+                const_cast<int *>(&group.width),
+                const_cast<int *>(&group.height), &stride,
+                &center_sigma, &center_block_step, &center_bm_range,
+                &radius, &center_ps_num, &center_ps_range,
+                &sigma_u, &sigma_v, &extractor,
+                const_cast<int *>(&source_width), &params, &center
+            };
+            cudaKernelNodeParams kernel_params {};
+            kernel_params.func = reinterpret_cast<void *>(
+                chroma ?
+                    (final_ ? bm3d<true, true, true, false, true> :
+                              bm3d<true, true, false, false, true>) :
+                    (final_ ? bm3d<true, false, true, false, true> :
+                              bm3d<true, false, false, false, true>)
+            );
+            kernel_params.gridDim = dim3(
+                (group.width + (4 * center_block_step - 1)) /
+                    (4 * center_block_step),
+                (group.height + (center_block_step - 1)) /
+                    center_block_step);
+            kernel_params.blockDim = dim3(32);
+            kernel_params.kernelParams = kernel_args;
+            if (cudaError_t result = cudaGraphAddKernelNode(
+                &center_node, graph.data, &scratch_clear, 1,
+                &kernel_params); result != cudaSuccess) {
+                return set_error(result, "cudaGraphAddKernelNode(center)");
+            }
+
+            cudaGraphNode_t scatter_node;
+            float * group_accum = d_accum + group.accum_row * stride;
+            void * scatter_args[] {
+                &group_accum, &d_scratch, &d_params,
+                const_cast<int *>(&group.width),
+                const_cast<int *>(&group.height), &stride,
+                const_cast<int *>(&group.planes), &radius, &chunk_size, &center
+            };
+            cudaKernelNodeParams scatter_params {};
+            scatter_params.func = reinterpret_cast<void *>(rolling_scatter);
+            scatter_params.gridDim = dim3(
+                (group.width + 255) / 256, group.height, group.planes);
+            scatter_params.blockDim = dim3(256);
+            scatter_params.kernelParams = scatter_args;
+            if (cudaError_t result = cudaGraphAddKernelNode(
+                &scatter_node, graph.data, &center_node, 1,
+                &scatter_params); result != cudaSuccess) {
+                return set_error(result, "cudaGraphAddKernelNode(scatter)");
+            }
+            previous = scatter_node;
+        }
+
+        cudaGraphNode_t normalize_node;
+        float * group_accum = d_accum + group.accum_row * stride;
+        void * normalize_args[] {
+            &group_accum,
+            const_cast<int *>(&group.width),
+            const_cast<int *>(&group.height), &stride,
+            const_cast<int *>(&group.planes), &chunk_size
+        };
+        cudaKernelNodeParams normalize_params {};
+        normalize_params.func = reinterpret_cast<void *>(rolling_normalize);
+        normalize_params.gridDim = dim3(
+            (group.width + 255) / 256, group.height,
+            chunk_size * group.planes);
+        normalize_params.blockDim = dim3(256);
+        normalize_params.kernelParams = normalize_args;
+        if (cudaError_t result = cudaGraphAddKernelNode(
+            &normalize_node, graph.data, &previous, 1,
+            &normalize_params); result != cudaSuccess) {
+            return set_error(result, "cudaGraphAddKernelNode(normalize)");
+        }
+        previous_group = normalize_node;
+
+        for (int output = 0; output < chunk_size; ++output) {
+            for (int group_plane = 0; group_plane < group.planes; ++group_plane) {
+                const int video_plane = group.first_plane + group_plane;
+                if (!(process_mask & (1 << video_plane))) {
+                    continue;
+                }
+                const size_t row = group.accum_row +
+                    (static_cast<size_t>(output) * group.planes + group_plane) *
+                        2 * group.height;
+                cudaMemcpy3DParms copy_params {};
+                copy_params.srcPtr = make_cudaPitchedPtr(
+                    d_accum + row * stride, pitch, group.width, group.height);
+                copy_params.dstPtr = make_cudaPitchedPtr(
+                    h_output + row * stride, pitch, group.width, group.height);
+                copy_params.extent = make_cudaExtent(
+                    static_cast<size_t>(group.width) * sizeof(float),
+                    group.height, 1);
+                copy_params.kind = cudaMemcpyDeviceToHost;
+                cudaGraphNode_t output_copy;
+                if (cudaError_t result = cudaGraphAddMemcpyNode(
+                    &output_copy, graph.data, &normalize_node, 1,
+                    &copy_params); result != cudaSuccess) {
+                    return set_error(result, "cudaGraphAddMemcpyNode(output DtoH)");
+                }
+            }
         }
     }
 

--- a/source/kernel.cu
+++ b/source/kernel.cu
@@ -25,7 +25,10 @@
 // WolframRhodium, 8 May 2021
 
 #include <cfloat>
+#include <string>
 #include <type_traits>
+#include <variant>
+#include <vector>
 
 #ifndef __CUDACC__
 #define __CUDACC__
@@ -52,7 +55,43 @@ cudaGraphExec_t get_graphexec(
     bool final_, float extractor
 ) noexcept;
 
+std::variant<cudaGraphExec_t, std::string> get_fused_graphexec(
+    float * d_res, float * d_src, float * h_res,
+    int * d_params, int * h_params,
+    int width, int height, int stride,
+    float sigma, int block_step, int bm_range,
+    int radius, int ps_num, int ps_range,
+    bool chroma, float sigma_u, float sigma_v,
+    bool final_, float extractor
+) noexcept;
+
 static constexpr int smem_stride = 32 + 1;
+
+extern "C" __global__ void temporal_normalize(
+    float * __restrict__ res,
+    int width, int height, int stride,
+    int num_planes, int centers
+) {
+    const int x = blockIdx.x * blockDim.x + threadIdx.x;
+    const int y = blockIdx.y;
+    const int plane = blockIdx.z;
+    if (x >= width || y >= height || plane >= num_planes) {
+        return;
+    }
+
+    const size_t image_stride = static_cast<size_t>(height) * stride;
+    const size_t plane_stride = 2 * image_stride;
+    const size_t center_stride = num_planes * plane_stride;
+    float weighted_sum = 0.0f;
+    float weight = 0.0f;
+    for (int center = 0; center < centers; ++center) {
+        const size_t offset = center * center_stride + plane * plane_stride + y * stride + x;
+        weighted_sum += res[offset];
+        weight += res[offset + image_stride];
+    }
+
+    res[plane * plane_stride + y * stride + x] = __fdiv_rn(weighted_sum, weight);
+}
 
 template <auto transform_impl, int stride=256, int howmany=8, int howmany_stride=32>
 __device__
@@ -363,7 +402,7 @@ static inline float collaborative_wiener(
 }
 
 // BM3D kernel
-template <bool temporal=false, bool chroma=false, bool final_=false>
+template <bool temporal=false, bool chroma=false, bool final_=false, bool fused=false>
 __global__
 #if __CUDA_ARCH__ == 750 || __CUDA_ARCH__ == 860
 __launch_bounds__(32, 16)
@@ -381,7 +420,10 @@ static void bm3d(
     float sigma, int block_step, int bm_range,
     int _radius, int ps_num, int ps_range,
     [[maybe_unused]] float sigma_u, [[maybe_unused]] float sigma_v,
-    float extractor // used for deteriministic summation
+    float extractor, // used for deteriministic summation
+    int source_temporal_width,
+    const int * __restrict__ fused_params,
+    int fused_center
 ) {
 
     __shared__ float buffer[8 * smem_stride];
@@ -406,11 +448,20 @@ static void bm3d(
 
     int temporal_stride = height * stride;
     int temporal_width = 2 * radius + 1;
-    int plane_stride = temporal_width * temporal_stride;
-    int clip_stride = (chroma ? 3 : 1) * temporal_width * temporal_stride;
+    int source_valid_width = source_temporal_width;
+    int source_center = radius;
+    int output_z = -1;
+    if constexpr (fused) {
+        source_valid_width = fused_params[0];
+        source_center = fused_params[1 + 2 * fused_center];
+        output_z = fused_params[2 + 2 * fused_center];
+    }
+    int source_plane_stride = (fused ? source_temporal_width : temporal_width) * temporal_stride;
+    int result_plane_stride = (fused ? 1 : temporal_width) * temporal_stride;
+    int clip_stride = (chroma ? 3 : 1) * source_plane_stride;
 
     float current_patch[8];
-    const float * const srcpc = &src[radius * temporal_stride + sub_lane_id];
+    const float * const srcpc = &src[source_center * temporal_stride + sub_lane_id];
 
     {
         const float * srcp = &srcpc[y * stride + x];
@@ -520,7 +571,13 @@ static void bm3d(
                 int frame_index8_x = 0;
                 int frame_index8_y = 0;
 
-                const float * temporal_srcpc = &src[temporal_index * temporal_stride + sub_lane_id];
+                int source_index = temporal_index;
+                if constexpr (fused) {
+                    source_index = min(max(
+                        source_center - radius + temporal_index, 0),
+                        source_valid_width - 1);
+                }
+                const float * temporal_srcpc = &src[source_index * temporal_stride + sub_lane_id];
 
                 for (int i = 0; i < ps_num; ++i) {
                     int xx = __shfl_sync(0xFFFFFFFF, last_index8_x, i, 8);
@@ -663,8 +720,8 @@ static void bm3d(
 
         if constexpr (chroma) {
             if (sigma < FLT_EPSILON) {
-                src += plane_stride;
-                res += plane_stride * 2;
+                src += source_plane_stride;
+                res += result_plane_stride * 2;
                 continue;
             }
         }
@@ -678,7 +735,13 @@ static void bm3d(
                 const float * refp;
                 if constexpr (temporal) {
                     int tmp_z = __shfl_sync(0xFFFFFFFF, index8_z, i, 8);
-                    refp = &src[tmp_z * temporal_stride + tmp_y * stride + tmp_x + sub_lane_id];
+                    int source_index = tmp_z;
+                    if constexpr (fused) {
+                        source_index = min(max(
+                            source_center - radius + tmp_z, 0),
+                            source_valid_width - 1);
+                    }
+                    refp = &src[source_index * temporal_stride + tmp_y * stride + tmp_x + sub_lane_id];
                 } else {
                     refp = &src[tmp_y * stride + tmp_x + sub_lane_id];
                 }
@@ -700,7 +763,13 @@ static void bm3d(
                 const float * srcp;
                 if constexpr (temporal) {
                     int tmp_z = __shfl_sync(0xFFFFFFFF, index8_z, i, 8);
-                    srcp = &src[tmp_z * temporal_stride + tmp_y * stride + tmp_x + sub_lane_id];
+                    int source_index = tmp_z;
+                    if constexpr (fused) {
+                        source_index = min(max(
+                            source_center - radius + tmp_z, 0),
+                            source_valid_width - 1);
+                    }
+                    srcp = &src[source_index * temporal_stride + tmp_y * stride + tmp_x + sub_lane_id];
                 } else {
                     srcp = &src[tmp_y * stride + tmp_x + sub_lane_id];
                 }
@@ -724,6 +793,12 @@ static void bm3d(
             int offset;
             if constexpr (temporal) {
                 int tmp_z = __shfl_sync(0xFFFFFFFF, index8_z, i, 8);
+                if constexpr (fused) {
+                    if (tmp_z != output_z) {
+                        continue;
+                    }
+                    tmp_z = 0;
+                }
                 offset = tmp_z * 2 * temporal_stride + tmp_y * stride + tmp_x;
             } else {
                 offset = tmp_y * stride + tmp_x;
@@ -751,8 +826,8 @@ static void bm3d(
             }
         }
 
-        src += plane_stride;
-        res += plane_stride * 2;
+        src += source_plane_stride;
+        res += result_plane_stride * 2;
     }
 }
 
@@ -802,13 +877,17 @@ cudaGraphExec_t get_graphexec(
     cudaGraphNode_t n_kernel;
     {
         cudaGraphNode_t dependencies[] { n_HtoD, n_memset };
+        int source_temporal_width = temporal_width;
+        const int * fused_params = nullptr;
+        int fused_center = 0;
 
         void * kernelArgs[] {
             &d_res, &d_src,
             &width, &height, &stride,
             &sigma, &block_step, &bm_range,
             &radius, &ps_num, &ps_range,
-            &sigma_u, &sigma_v, &extractor
+            &sigma_u, &sigma_v, &extractor,
+            &source_temporal_width, &fused_params, &fused_center
         };
 
         cudaKernelNodeParams kernel_params {};
@@ -838,7 +917,6 @@ cudaGraphExec_t get_graphexec(
     cudaGraphNode_t n_DtoH;
     {
         cudaGraphNode_t dependencies[] { n_kernel };
-
         cudaMemcpy3DParms copy_params {};
         int logical_height { num_planes * temporal_width * 2 * height };
         copy_params.srcPtr = make_cudaPitchedPtr(
@@ -861,4 +939,164 @@ cudaGraphExec_t get_graphexec(
     cudaGraphDestroy(graph);
 
     return graphexecp;
+}
+
+std::variant<cudaGraphExec_t, std::string> get_fused_graphexec(
+    float * d_res, float * d_src, float * h_res,
+    int * d_params, int * h_params,
+    int width, int height, int stride,
+    float sigma, int block_step, int bm_range,
+    int radius, int ps_num, int ps_range,
+    bool chroma, float sigma_u, float sigma_v,
+    bool final_, float extractor
+) noexcept {
+    const auto set_error = [](cudaError_t result, const char * expression) {
+        return std::string { "'" } + expression + "' failed: " +
+            cudaGetErrorString(result);
+    };
+
+    struct GraphGuard {
+        cudaGraph_t data {};
+
+        ~GraphGuard() noexcept {
+            if (data) {
+                cudaGraphDestroy(data);
+            }
+        }
+    } graph;
+
+    const size_t pitch = stride * sizeof(float);
+    int centers = 2 * radius + 1;
+    int source_temporal_width = 4 * radius + 1;
+    int num_planes = chroma ? 3 : 1;
+    const size_t source_rows = static_cast<size_t>(final_ ? 2 : 1) *
+        num_planes * source_temporal_width * height;
+
+    if (cudaError_t result = cudaGraphCreate(&graph.data, 0); result != cudaSuccess) {
+        return set_error(result, "cudaGraphCreate");
+    }
+
+    cudaGraphNode_t n_HtoD;
+    {
+        cudaMemcpy3DParms copy_params {};
+        copy_params.srcPtr = make_cudaPitchedPtr(
+            h_res, pitch, width, source_rows);
+        copy_params.dstPtr = make_cudaPitchedPtr(
+            d_src, pitch, width, source_rows);
+        copy_params.extent = make_cudaExtent(
+            width * sizeof(float), source_rows, 1);
+        copy_params.kind = cudaMemcpyHostToDevice;
+        if (cudaError_t result = cudaGraphAddMemcpyNode(
+            &n_HtoD, graph.data, nullptr, 0, &copy_params); result != cudaSuccess) {
+            return set_error(result, "cudaGraphAddMemcpyNode(HtoD)");
+        }
+    }
+
+    cudaGraphNode_t n_params;
+    if (cudaError_t result = cudaGraphAddMemcpyNode1D(
+        &n_params, graph.data, nullptr, 0, d_params, h_params,
+        (1 + 2 * static_cast<size_t>(centers)) * sizeof(int),
+        cudaMemcpyHostToDevice); result != cudaSuccess) {
+        return set_error(result, "cudaGraphAddMemcpyNode1D(params)");
+    }
+
+    cudaGraphNode_t n_memset;
+    {
+        cudaMemsetParams memset_params {};
+        memset_params.dst = d_res;
+        memset_params.pitch = pitch;
+        memset_params.value = 0;
+        memset_params.elementSize = 4;
+        memset_params.width = width;
+        memset_params.height = static_cast<size_t>(centers) * num_planes * 2 * height;
+        if (cudaError_t result = cudaGraphAddMemsetNode(
+            &n_memset, graph.data, nullptr, 0, &memset_params); result != cudaSuccess) {
+            return set_error(result, "cudaGraphAddMemsetNode");
+        }
+    }
+
+    std::vector<cudaGraphNode_t> center_nodes(centers);
+    for (int center = 0; center < centers; ++center) {
+        cudaGraphNode_t dependencies[] { n_HtoD, n_params, n_memset };
+        const size_t center_stride = static_cast<size_t>(num_planes) * 2 * height * stride;
+        float * center_res = d_res + center * center_stride;
+        const int * fused_params = d_params;
+        int fused_center = center;
+
+        void * kernel_args[] {
+            &center_res, &d_src,
+            &width, &height, &stride,
+            &sigma, &block_step, &bm_range,
+            &radius, &ps_num, &ps_range,
+            &sigma_u, &sigma_v, &extractor,
+            &source_temporal_width,
+            &fused_params, &fused_center
+        };
+
+        cudaKernelNodeParams kernel_params {};
+        kernel_params.func = reinterpret_cast<void *>(
+            chroma ? (final_ ? bm3d<true, true, true, true> : bm3d<true, true, false, true>)
+                   : (final_ ? bm3d<true, false, true, true> : bm3d<true, false, false, true>)
+        );
+        kernel_params.gridDim = dim3(
+            (width + (4 * block_step - 1)) / (4 * block_step),
+            (height + (block_step - 1)) / block_step);
+        kernel_params.blockDim = dim3(32);
+        kernel_params.kernelParams = kernel_args;
+
+        if (cudaError_t result = cudaGraphAddKernelNode(
+            &center_nodes[center], graph.data,
+            dependencies, std::extent_v<decltype(dependencies)>,
+            &kernel_params); result != cudaSuccess) {
+            return set_error(result, "cudaGraphAddKernelNode(center)");
+        }
+    }
+
+    cudaGraphNode_t n_normalize;
+    {
+        void * kernel_args[] {
+            &d_res, &width, &height, &stride,
+            &num_planes, &centers
+        };
+        cudaKernelNodeParams kernel_params {};
+        kernel_params.func = reinterpret_cast<void *>(temporal_normalize);
+        kernel_params.gridDim = dim3((width + 255) / 256, height, num_planes);
+        kernel_params.blockDim = dim3(256);
+        kernel_params.kernelParams = kernel_args;
+        if (cudaError_t result = cudaGraphAddKernelNode(
+            &n_normalize, graph.data,
+            center_nodes.data(), center_nodes.size(),
+            &kernel_params); result != cudaSuccess) {
+            return set_error(result, "cudaGraphAddKernelNode(normalize)");
+        }
+    }
+
+    cudaGraphNode_t dependencies[] { n_normalize };
+    for (int plane = 0; plane < num_planes; ++plane) {
+        const size_t plane_offset = static_cast<size_t>(plane) * 2 * height * pitch;
+        cudaMemcpy3DParms copy_params {};
+        copy_params.srcPtr = make_cudaPitchedPtr(
+            reinterpret_cast<char *>(d_res) + plane_offset,
+            pitch, width, 2 * height);
+        copy_params.dstPtr = make_cudaPitchedPtr(
+            reinterpret_cast<char *>(h_res) + plane_offset,
+            pitch, width, 2 * height);
+        copy_params.extent = make_cudaExtent(width * sizeof(float), height, 1);
+        copy_params.kind = cudaMemcpyDeviceToHost;
+
+        cudaGraphNode_t n_DtoH;
+        if (cudaError_t result = cudaGraphAddMemcpyNode(
+            &n_DtoH, graph.data,
+            dependencies, std::extent_v<decltype(dependencies)>,
+            &copy_params); result != cudaSuccess) {
+            return set_error(result, "cudaGraphAddMemcpyNode(DtoH)");
+        }
+    }
+
+    cudaGraphExec_t graphexec {};
+    if (cudaError_t result = cudaGraphInstantiate(
+        &graphexec, graph.data, nullptr, nullptr, 0); result != cudaSuccess) {
+        return set_error(result, "cudaGraphInstantiate");
+    }
+    return graphexec;
 }

--- a/source/kernel.cu
+++ b/source/kernel.cu
@@ -55,16 +55,6 @@ cudaGraphExec_t get_graphexec(
     bool final_, float extractor
 ) noexcept;
 
-std::variant<cudaGraphExec_t, std::string> get_fused_graphexec(
-    float * d_res, float * d_src, float * h_res,
-    int * d_params, int * h_params,
-    int width, int height, int stride,
-    float sigma, int block_step, int bm_range,
-    int radius, int ps_num, int ps_range,
-    bool chroma, float sigma_u, float sigma_v,
-    bool final_, float extractor
-) noexcept;
-
 std::variant<cudaGraphExec_t, std::string> get_rolling_graphexec(
     float * d_accum, float * d_scratch, float * d_src,
     float * h_src, float * h_output,
@@ -75,35 +65,9 @@ std::variant<cudaGraphExec_t, std::string> get_rolling_graphexec(
     int radius, int chunk_size, int process_mask, int video_planes,
     int subsampling_w, int subsampling_h,
     bool chroma, bool final_, float extractor
-) noexcept;
+);
 
 static constexpr int smem_stride = 32 + 1;
-
-extern "C" __global__ void temporal_normalize(
-    float * __restrict__ res,
-    int width, int height, int stride,
-    int num_planes, int centers
-) {
-    const int x = blockIdx.x * blockDim.x + threadIdx.x;
-    const int y = blockIdx.y;
-    const int plane = blockIdx.z;
-    if (x >= width || y >= height || plane >= num_planes) {
-        return;
-    }
-
-    const size_t image_stride = static_cast<size_t>(height) * stride;
-    const size_t plane_stride = 2 * image_stride;
-    const size_t center_stride = num_planes * plane_stride;
-    float weighted_sum = 0.0f;
-    float weight = 0.0f;
-    for (int center = 0; center < centers; ++center) {
-        const size_t offset = center * center_stride + plane * plane_stride + y * stride + x;
-        weighted_sum += res[offset];
-        weight += res[offset + image_stride];
-    }
-
-    res[plane * plane_stride + y * stride + x] = __fdiv_rn(weighted_sum, weight);
-}
 
 extern "C" __global__ void rolling_scatter(
     float * __restrict__ accum,
@@ -472,7 +436,7 @@ static inline float collaborative_wiener(
 // BM3D kernel
 template <
     bool temporal=false, bool chroma=false, bool final_=false,
-    bool fused=false, bool rolling=false
+    bool rolling=false
 >
 __global__
 #if __CUDA_ARCH__ == 750 || __CUDA_ARCH__ == 860
@@ -493,8 +457,8 @@ static void bm3d(
     [[maybe_unused]] float sigma_u, [[maybe_unused]] float sigma_v,
     float extractor, // used for deteriministic summation
     int source_temporal_width,
-    const int * __restrict__ fused_params,
-    int graph_center
+    const int * __restrict__ rolling_params,
+    int center
 ) {
 
     __shared__ float buffer[8 * smem_stride];
@@ -521,18 +485,13 @@ static void bm3d(
     int temporal_width = 2 * radius + 1;
     int source_valid_width = source_temporal_width;
     int source_center = radius;
-    int output_z = -1;
-    if constexpr (fused) {
-        source_valid_width = fused_params[0];
-        source_center = fused_params[1 + 2 * graph_center];
-        output_z = fused_params[2 + 2 * graph_center];
-    } else if constexpr (rolling) {
-        source_valid_width = fused_params[0];
-        source_center = fused_params[1 + graph_center];
+    if constexpr (rolling) {
+        source_valid_width = rolling_params[0];
+        source_center = rolling_params[1 + center];
     }
-    int source_plane_stride = ((fused || rolling) ?
+    int source_plane_stride = (rolling ?
         source_temporal_width : temporal_width) * temporal_stride;
-    int result_plane_stride = (fused ? 1 : temporal_width) * temporal_stride;
+    int result_plane_stride = temporal_width * temporal_stride;
     int clip_stride = (chroma ? 3 : 1) * source_plane_stride;
 
     float current_patch[8];
@@ -647,7 +606,7 @@ static void bm3d(
                 int frame_index8_y = 0;
 
                 int source_index = temporal_index;
-                if constexpr (fused || rolling) {
+                if constexpr (rolling) {
                     source_index = min(max(
                         source_center - radius + temporal_index, 0),
                         source_valid_width - 1);
@@ -811,7 +770,7 @@ static void bm3d(
                 if constexpr (temporal) {
                     int tmp_z = __shfl_sync(0xFFFFFFFF, index8_z, i, 8);
                     int source_index = tmp_z;
-                    if constexpr (fused || rolling) {
+                    if constexpr (rolling) {
                         source_index = min(max(
                             source_center - radius + tmp_z, 0),
                             source_valid_width - 1);
@@ -839,7 +798,7 @@ static void bm3d(
                 if constexpr (temporal) {
                     int tmp_z = __shfl_sync(0xFFFFFFFF, index8_z, i, 8);
                     int source_index = tmp_z;
-                    if constexpr (fused || rolling) {
+                    if constexpr (rolling) {
                         source_index = min(max(
                             source_center - radius + tmp_z, 0),
                             source_valid_width - 1);
@@ -868,12 +827,6 @@ static void bm3d(
             int offset;
             if constexpr (temporal) {
                 int tmp_z = __shfl_sync(0xFFFFFFFF, index8_z, i, 8);
-                if constexpr (fused) {
-                    if (tmp_z != output_z) {
-                        continue;
-                    }
-                    tmp_z = 0;
-                }
                 offset = tmp_z * 2 * temporal_stride + tmp_y * stride + tmp_x;
             } else {
                 offset = tmp_y * stride + tmp_x;
@@ -953,8 +906,8 @@ cudaGraphExec_t get_graphexec(
     {
         cudaGraphNode_t dependencies[] { n_HtoD, n_memset };
         int source_temporal_width = temporal_width;
-        const int * fused_params = nullptr;
-        int fused_center = 0;
+        const int * rolling_params = nullptr;
+        int center = 0;
 
         void * kernelArgs[] {
             &d_res, &d_src,
@@ -962,7 +915,7 @@ cudaGraphExec_t get_graphexec(
             &sigma, &block_step, &bm_range,
             &radius, &ps_num, &ps_range,
             &sigma_u, &sigma_v, &extractor,
-            &source_temporal_width, &fused_params, &fused_center
+            &source_temporal_width, &rolling_params, &center
         };
 
         cudaKernelNodeParams kernel_params {};
@@ -1016,166 +969,6 @@ cudaGraphExec_t get_graphexec(
     return graphexecp;
 }
 
-std::variant<cudaGraphExec_t, std::string> get_fused_graphexec(
-    float * d_res, float * d_src, float * h_res,
-    int * d_params, int * h_params,
-    int width, int height, int stride,
-    float sigma, int block_step, int bm_range,
-    int radius, int ps_num, int ps_range,
-    bool chroma, float sigma_u, float sigma_v,
-    bool final_, float extractor
-) noexcept {
-    const auto set_error = [](cudaError_t result, const char * expression) {
-        return std::string { "'" } + expression + "' failed: " +
-            cudaGetErrorString(result);
-    };
-
-    struct GraphGuard {
-        cudaGraph_t data {};
-
-        ~GraphGuard() noexcept {
-            if (data) {
-                cudaGraphDestroy(data);
-            }
-        }
-    } graph;
-
-    const size_t pitch = stride * sizeof(float);
-    int centers = 2 * radius + 1;
-    int source_temporal_width = 4 * radius + 1;
-    int num_planes = chroma ? 3 : 1;
-    const size_t source_rows = static_cast<size_t>(final_ ? 2 : 1) *
-        num_planes * source_temporal_width * height;
-
-    if (cudaError_t result = cudaGraphCreate(&graph.data, 0); result != cudaSuccess) {
-        return set_error(result, "cudaGraphCreate");
-    }
-
-    cudaGraphNode_t n_HtoD;
-    {
-        cudaMemcpy3DParms copy_params {};
-        copy_params.srcPtr = make_cudaPitchedPtr(
-            h_res, pitch, width, source_rows);
-        copy_params.dstPtr = make_cudaPitchedPtr(
-            d_src, pitch, width, source_rows);
-        copy_params.extent = make_cudaExtent(
-            width * sizeof(float), source_rows, 1);
-        copy_params.kind = cudaMemcpyHostToDevice;
-        if (cudaError_t result = cudaGraphAddMemcpyNode(
-            &n_HtoD, graph.data, nullptr, 0, &copy_params); result != cudaSuccess) {
-            return set_error(result, "cudaGraphAddMemcpyNode(HtoD)");
-        }
-    }
-
-    cudaGraphNode_t n_params;
-    if (cudaError_t result = cudaGraphAddMemcpyNode1D(
-        &n_params, graph.data, nullptr, 0, d_params, h_params,
-        (1 + 2 * static_cast<size_t>(centers)) * sizeof(int),
-        cudaMemcpyHostToDevice); result != cudaSuccess) {
-        return set_error(result, "cudaGraphAddMemcpyNode1D(params)");
-    }
-
-    cudaGraphNode_t n_memset;
-    {
-        cudaMemsetParams memset_params {};
-        memset_params.dst = d_res;
-        memset_params.pitch = pitch;
-        memset_params.value = 0;
-        memset_params.elementSize = 4;
-        memset_params.width = width;
-        memset_params.height = static_cast<size_t>(centers) * num_planes * 2 * height;
-        if (cudaError_t result = cudaGraphAddMemsetNode(
-            &n_memset, graph.data, nullptr, 0, &memset_params); result != cudaSuccess) {
-            return set_error(result, "cudaGraphAddMemsetNode");
-        }
-    }
-
-    std::vector<cudaGraphNode_t> center_nodes(centers);
-    for (int center = 0; center < centers; ++center) {
-        cudaGraphNode_t dependencies[] { n_HtoD, n_params, n_memset };
-        const size_t center_stride = static_cast<size_t>(num_planes) * 2 * height * stride;
-        float * center_res = d_res + center * center_stride;
-        const int * fused_params = d_params;
-        int fused_center = center;
-
-        void * kernel_args[] {
-            &center_res, &d_src,
-            &width, &height, &stride,
-            &sigma, &block_step, &bm_range,
-            &radius, &ps_num, &ps_range,
-            &sigma_u, &sigma_v, &extractor,
-            &source_temporal_width,
-            &fused_params, &fused_center
-        };
-
-        cudaKernelNodeParams kernel_params {};
-        kernel_params.func = reinterpret_cast<void *>(
-            chroma ? (final_ ? bm3d<true, true, true, true> : bm3d<true, true, false, true>)
-                   : (final_ ? bm3d<true, false, true, true> : bm3d<true, false, false, true>)
-        );
-        kernel_params.gridDim = dim3(
-            (width + (4 * block_step - 1)) / (4 * block_step),
-            (height + (block_step - 1)) / block_step);
-        kernel_params.blockDim = dim3(32);
-        kernel_params.kernelParams = kernel_args;
-
-        if (cudaError_t result = cudaGraphAddKernelNode(
-            &center_nodes[center], graph.data,
-            dependencies, std::extent_v<decltype(dependencies)>,
-            &kernel_params); result != cudaSuccess) {
-            return set_error(result, "cudaGraphAddKernelNode(center)");
-        }
-    }
-
-    cudaGraphNode_t n_normalize;
-    {
-        void * kernel_args[] {
-            &d_res, &width, &height, &stride,
-            &num_planes, &centers
-        };
-        cudaKernelNodeParams kernel_params {};
-        kernel_params.func = reinterpret_cast<void *>(temporal_normalize);
-        kernel_params.gridDim = dim3((width + 255) / 256, height, num_planes);
-        kernel_params.blockDim = dim3(256);
-        kernel_params.kernelParams = kernel_args;
-        if (cudaError_t result = cudaGraphAddKernelNode(
-            &n_normalize, graph.data,
-            center_nodes.data(), center_nodes.size(),
-            &kernel_params); result != cudaSuccess) {
-            return set_error(result, "cudaGraphAddKernelNode(normalize)");
-        }
-    }
-
-    cudaGraphNode_t dependencies[] { n_normalize };
-    for (int plane = 0; plane < num_planes; ++plane) {
-        const size_t plane_offset = static_cast<size_t>(plane) * 2 * height * pitch;
-        cudaMemcpy3DParms copy_params {};
-        copy_params.srcPtr = make_cudaPitchedPtr(
-            reinterpret_cast<char *>(d_res) + plane_offset,
-            pitch, width, 2 * height);
-        copy_params.dstPtr = make_cudaPitchedPtr(
-            reinterpret_cast<char *>(h_res) + plane_offset,
-            pitch, width, 2 * height);
-        copy_params.extent = make_cudaExtent(width * sizeof(float), height, 1);
-        copy_params.kind = cudaMemcpyDeviceToHost;
-
-        cudaGraphNode_t n_DtoH;
-        if (cudaError_t result = cudaGraphAddMemcpyNode(
-            &n_DtoH, graph.data,
-            dependencies, std::extent_v<decltype(dependencies)>,
-            &copy_params); result != cudaSuccess) {
-            return set_error(result, "cudaGraphAddMemcpyNode(DtoH)");
-        }
-    }
-
-    cudaGraphExec_t graphexec {};
-    if (cudaError_t result = cudaGraphInstantiate(
-        &graphexec, graph.data, nullptr, nullptr, 0); result != cudaSuccess) {
-        return set_error(result, "cudaGraphInstantiate");
-    }
-    return graphexec;
-}
-
 std::variant<cudaGraphExec_t, std::string> get_rolling_graphexec(
     float * d_accum, float * d_scratch, float * d_src,
     float * h_src, float * h_output,
@@ -1186,7 +979,7 @@ std::variant<cudaGraphExec_t, std::string> get_rolling_graphexec(
     int radius, int chunk_size, int process_mask, int video_planes,
     int subsampling_w, int subsampling_h,
     bool chroma, bool final_, float extractor
-) noexcept {
+) {
     const auto set_error = [](cudaError_t result, const char * expression) {
         return std::string { "'" } + expression + "' failed: " +
             cudaGetErrorString(result);
@@ -1349,10 +1142,10 @@ std::variant<cudaGraphExec_t, std::string> get_rolling_graphexec(
             cudaKernelNodeParams kernel_params {};
             kernel_params.func = reinterpret_cast<void *>(
                 chroma ?
-                    (final_ ? bm3d<true, true, true, false, true> :
-                              bm3d<true, true, false, false, true>) :
-                    (final_ ? bm3d<true, false, true, false, true> :
-                              bm3d<true, false, false, false, true>)
+                    (final_ ? bm3d<true, true, true, true> :
+                              bm3d<true, true, false, true>) :
+                    (final_ ? bm3d<true, false, true, true> :
+                              bm3d<true, false, false, true>)
             );
             kernel_params.gridDim = dim3(
                 (group.width + (4 * center_block_step - 1)) /

--- a/source/source.cpp
+++ b/source/source.cpp
@@ -29,6 +29,7 @@
 #include <mutex>
 #include <shared_mutex>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <type_traits>
 #include <unordered_map>
@@ -60,6 +61,18 @@ extern std::variant<cudaGraphExec_t, std::string> get_fused_graphexec(
     int radius, int ps_num, int ps_range,
     bool chroma, float sigma_u, float sigma_v,
     bool final_, float extractor
+) noexcept;
+
+extern std::variant<cudaGraphExec_t, std::string> get_rolling_graphexec(
+    float * d_accum, float * d_scratch, float * d_src,
+    float * h_src, float * h_output,
+    int * d_params, int * h_params,
+    int width, int height, int stride,
+    const float sigma[3], const int block_step[3],
+    const int bm_range[3], const int ps_num[3], const int ps_range[3],
+    int radius, int chunk_size, int process_mask, int video_planes,
+    int subsampling_w, int subsampling_h,
+    bool chroma, bool final_, float extractor
 ) noexcept;
 
 #define checkError(expr) do {                                            \
@@ -850,6 +863,609 @@ static void VS_CC BM3DCreate(
     BM3DCreateImpl(in, out, userData, core, vsapi, false);
 }
 
+struct RollingResource {
+    Resource<float *, cudaFree> d_src;
+    Resource<float *, cudaFree> d_scratch;
+    Resource<float *, cudaFree> d_accum;
+    Resource<float *, cudaFreeHost> h_src;
+    Resource<float *, cudaFreeHost> h_output;
+    Resource<int *, cudaFree> d_params;
+    Resource<int *, cudaFreeHost> h_params;
+    Resource<cudaStream_t, cudaStreamDestroy> stream;
+    Resource<cudaGraphExec_t, cudaGraphExecDestroy> graphexec;
+};
+
+struct RollingData {
+    VSNodeRef * node {};
+    VSNodeRef * ref_node {};
+    const VSVideoInfo * vi {};
+
+    int radius {};
+    int chunk_size {};
+    int device_id {};
+    int d_pitch {};
+    bool chroma {};
+    bool final_ {};
+    bool process[3] {};
+
+    size_t source_rows {};
+    size_t output_rows {};
+    size_t output_plane_rows[3] {};
+    size_t output_step_rows[3] {};
+    RollingResource resource;
+
+    mutable std::shared_mutex cache_lock;
+    int cached_start { -1 };
+    std::vector<const VSFrameRef *> cached_frames;
+};
+
+struct RollingRequest {
+    int chunk_start;
+};
+
+static bool checked_mul(size_t lhs, size_t rhs, size_t & result) noexcept {
+    if (lhs && rhs > std::numeric_limits<size_t>::max() / lhs) {
+        return false;
+    }
+    result = lhs * rhs;
+    return true;
+}
+
+static bool checked_add(size_t lhs, size_t rhs, size_t & result) noexcept {
+    if (rhs > std::numeric_limits<size_t>::max() - lhs) {
+        return false;
+    }
+    result = lhs + rhs;
+    return true;
+}
+
+static void VS_CC RollingInit(
+    VSMap *in, VSMap *out, void **instanceData, VSNode *node,
+    VSCore *core, const VSAPI *vsapi
+) noexcept {
+    auto d = static_cast<RollingData *>(*instanceData);
+    vsapi->setVideoInfo(d->vi, 1, node);
+}
+
+static const VSFrameRef * rolling_cache_get(
+    const RollingData * d, int n, const VSAPI * vsapi
+) noexcept {
+    std::shared_lock lock { d->cache_lock };
+    const int offset = n - d->cached_start;
+    if (offset < 0 || offset >= std::ssize(d->cached_frames)) {
+        return nullptr;
+    }
+    return vsapi->cloneFrameRef(d->cached_frames[offset]);
+}
+
+static const VSFrameRef *VS_CC RollingGetFrame(
+    int n, int activationReason, void **instanceData, void **frameData,
+    VSFrameContext *frameCtx, VSCore *core, const VSAPI *vsapi
+) noexcept {
+    auto d = static_cast<RollingData *>(*instanceData);
+
+    if (activationReason == arInitial) {
+        const int chunk_start = n / d->chunk_size * d->chunk_size;
+        *frameData = new RollingRequest { chunk_start };
+
+        if (const VSFrameRef * cached = rolling_cache_get(d, n, vsapi)) {
+            delete static_cast<RollingRequest *>(*frameData);
+            *frameData = nullptr;
+            return cached;
+        }
+
+        const int64_t first = std::max<int64_t>(
+            static_cast<int64_t>(chunk_start) - 2LL * d->radius, 0);
+        const int64_t last = std::min<int64_t>(
+            static_cast<int64_t>(chunk_start) + d->chunk_size - 1 +
+                2LL * d->radius,
+            d->vi->numFrames - 1);
+        for (int64_t frame = first; frame <= last; ++frame) {
+            vsapi->requestFrameFilter(static_cast<int>(frame), d->node, frameCtx);
+        }
+        if (d->final_) {
+            for (int64_t frame = first; frame <= last; ++frame) {
+                vsapi->requestFrameFilter(
+                    static_cast<int>(frame), d->ref_node, frameCtx);
+            }
+        }
+        return nullptr;
+    }
+
+    if (activationReason == arError) {
+        delete static_cast<RollingRequest *>(*frameData);
+        *frameData = nullptr;
+        return nullptr;
+    }
+
+    if (activationReason != arAllFramesReady) {
+        return nullptr;
+    }
+
+    std::unique_ptr<RollingRequest> request {
+        static_cast<RollingRequest *>(*frameData)
+    };
+    *frameData = nullptr;
+
+    if (const VSFrameRef * cached = rolling_cache_get(d, n, vsapi)) {
+        return cached;
+    }
+
+    const auto set_error = [&](const std::string & error_message) {
+        vsapi->setFilterError(
+            ("BM3Dv2 rolling: " + error_message).c_str(), frameCtx);
+        return static_cast<const VSFrameRef *>(nullptr);
+    };
+
+    if (cudaError_t result = cudaSetDevice(d->device_id); result != cudaSuccess) {
+        return set_error(cudaGetErrorString(result));
+    }
+
+    const int chunk_start = request->chunk_start;
+    const int valid_outputs = std::min(
+        d->chunk_size, d->vi->numFrames - chunk_start);
+    const int logical_first = chunk_start - 2 * d->radius;
+    const int logical_source_width = d->chunk_size + 4 * d->radius;
+    const int centers = d->chunk_size + 2 * d->radius;
+    const int first_frame = std::max(logical_first, 0);
+    const int last_frame = std::min(
+        chunk_start + d->chunk_size - 1 + 2 * d->radius,
+        d->vi->numFrames - 1);
+    const int unique_frames = last_frame - first_frame + 1;
+
+    using freeFrame_t = decltype(vsapi->freeFrame);
+    using FramePtr = std::unique_ptr<const VSFrameRef, const freeFrame_t &>;
+    std::vector<FramePtr> source_frames;
+    std::vector<FramePtr> reference_frames;
+    source_frames.reserve(unique_frames);
+    reference_frames.reserve(d->final_ ? unique_frames : 0);
+    for (int frame = first_frame; frame <= last_frame; ++frame) {
+        source_frames.emplace_back(
+            vsapi->getFrameFilter(frame, d->node, frameCtx), vsapi->freeFrame);
+    }
+    if (d->final_) {
+        for (int frame = first_frame; frame <= last_frame; ++frame) {
+            reference_frames.emplace_back(
+                vsapi->getFrameFilter(frame, d->ref_node, frameCtx),
+                vsapi->freeFrame);
+        }
+    }
+
+    RollingResource & resource = d->resource;
+    const int d_stride = d->d_pitch / sizeof(float);
+    auto stage_plane = [&](
+        float * & h_dst, const std::vector<FramePtr> & frames, int plane,
+        int plane_height
+    ) {
+        const int width = vsapi->getFrameWidth(frames.front().get(), plane);
+        const int source_pitch = vsapi->getStride(frames.front().get(), plane);
+        for (int logical = 0; logical < logical_source_width; ++logical) {
+            const int frame = std::clamp(
+                logical_first + logical, 0, d->vi->numFrames - 1);
+            const VSFrameRef * source = frames[frame - first_frame].get();
+            vs_bitblt(
+                h_dst, d->d_pitch, vsapi->getReadPtr(source, plane),
+                source_pitch, width * sizeof(float), plane_height);
+            h_dst += static_cast<size_t>(d_stride) * plane_height;
+        }
+    };
+
+    if (d->source_rows) {
+        float * h_dst = resource.h_src;
+        if (d->chroma) {
+            if (d->final_) {
+                for (int plane = 0; plane < 3; ++plane) {
+                    stage_plane(h_dst, reference_frames, plane, d->vi->height);
+                }
+            }
+            for (int plane = 0; plane < 3; ++plane) {
+                stage_plane(h_dst, source_frames, plane, d->vi->height);
+            }
+        } else {
+            for (int plane = 0; plane < d->vi->format->numPlanes; ++plane) {
+                if (!d->process[plane]) {
+                    continue;
+                }
+                const int plane_height = vsapi->getFrameHeight(
+                    source_frames.front().get(), plane);
+                if (d->final_) {
+                    stage_plane(h_dst, reference_frames, plane, plane_height);
+                }
+                stage_plane(h_dst, source_frames, plane, plane_height);
+            }
+        }
+
+        resource.h_params.data[0] = logical_source_width;
+        for (int center = 0; center < centers; ++center) {
+            const int frame = std::clamp(
+                chunk_start - d->radius + center,
+                0, d->vi->numFrames - 1);
+            resource.h_params.data[1 + center] = frame - logical_first;
+        }
+
+        if (cudaError_t result = cudaGraphLaunch(
+            resource.graphexec, resource.stream); result != cudaSuccess) {
+            return set_error(cudaGetErrorString(result));
+        }
+        if (cudaError_t result = cudaStreamSynchronize(resource.stream);
+            result != cudaSuccess) {
+            return set_error(cudaGetErrorString(result));
+        }
+    }
+
+    std::vector<const VSFrameRef *> new_cache;
+    new_cache.reserve(valid_outputs);
+    for (int output = 0; output < valid_outputs; ++output) {
+        const VSFrameRef * source =
+            source_frames[chunk_start + output - first_frame].get();
+        const VSFrameRef * plane_sources[] {
+            d->process[0] ? nullptr : source,
+            d->process[1] ? nullptr : source,
+            d->process[2] ? nullptr : source
+        };
+        constexpr int planes[] { 0, 1, 2 };
+        VSFrameRef * destination = vsapi->newVideoFrame2(
+            d->vi->format, d->vi->width, d->vi->height,
+            plane_sources, planes, source, core);
+
+        for (int plane = 0; plane < d->vi->format->numPlanes; ++plane) {
+            if (!d->process[plane]) {
+                continue;
+            }
+            const int plane_width = vsapi->getFrameWidth(source, plane);
+            const int plane_height = vsapi->getFrameHeight(source, plane);
+            const size_t row = d->output_plane_rows[plane] +
+                static_cast<size_t>(output) * d->output_step_rows[plane];
+            const float * h_source = resource.h_output.data + row * d_stride;
+            vs_bitblt(
+                vsapi->getWritePtr(destination, plane),
+                vsapi->getStride(destination, plane),
+                h_source, d->d_pitch,
+                plane_width * sizeof(float), plane_height);
+        }
+        new_cache.push_back(destination);
+    }
+
+    std::vector<const VSFrameRef *> old_cache;
+    {
+        std::unique_lock lock { d->cache_lock };
+        old_cache = std::move(d->cached_frames);
+        d->cached_frames = std::move(new_cache);
+        d->cached_start = chunk_start;
+    }
+    for (const VSFrameRef * frame : old_cache) {
+        vsapi->freeFrame(frame);
+    }
+    return rolling_cache_get(d, n, vsapi);
+}
+
+static void VS_CC RollingFree(
+    void *instanceData, VSCore *core, const VSAPI *vsapi
+) noexcept {
+    auto d = static_cast<RollingData *>(instanceData);
+    std::vector<const VSFrameRef *> cached_frames;
+    {
+        std::unique_lock lock { d->cache_lock };
+        cached_frames = std::move(d->cached_frames);
+        d->cached_start = -1;
+    }
+    for (const VSFrameRef * frame : cached_frames) {
+        vsapi->freeFrame(frame);
+    }
+    vsapi->freeNode(d->node);
+    vsapi->freeNode(d->ref_node);
+    cudaSetDevice(d->device_id);
+    delete d;
+}
+
+static void RollingCreate(
+    const VSMap *in, VSMap *out, int chunk_size,
+    VSCore *core, const VSAPI *vsapi
+) noexcept {
+    try {
+    auto d = std::make_unique<RollingData>();
+
+    const auto set_error = [&](const std::string & error_message) {
+        vsapi->setError(out, ("BM3Dv2 rolling: " + error_message).c_str());
+        vsapi->freeNode(d->node);
+        vsapi->freeNode(d->ref_node);
+    };
+
+    d->node = vsapi->propGetNode(in, "clip", 0, nullptr);
+    d->vi = vsapi->getVideoInfo(d->node);
+    const int width = d->vi->width;
+    const int height = d->vi->height;
+    if (
+        !isConstantFormat(d->vi) || d->vi->format->sampleType == stInteger ||
+        d->vi->format->bitsPerSample != 32) {
+        return set_error("only constant format 32bit float input supported");
+    }
+
+    int error;
+    d->ref_node = vsapi->propGetNode(in, "ref", 0, &error);
+    if (error) {
+        d->ref_node = nullptr;
+        d->final_ = false;
+    } else {
+        const VSVideoInfo * ref_vi = vsapi->getVideoInfo(d->ref_node);
+        if (ref_vi->format->id != d->vi->format->id) {
+            return set_error("\"ref\" must be of the same format as \"clip\"");
+        }
+        if (ref_vi->width != width || ref_vi->height != height) {
+            return set_error("\"ref\" must be of the same dimensions as \"clip\"");
+        }
+        if (ref_vi->numFrames != d->vi->numFrames) {
+            return set_error("\"ref\" must be of the same number of frames as \"clip\"");
+        }
+        d->final_ = true;
+    }
+
+    float sigma[3];
+    for (int plane = 0; plane < 3; ++plane) {
+        sigma[plane] = static_cast<float>(
+            vsapi->propGetFloat(in, "sigma", plane, &error));
+        if (error) {
+            sigma[plane] = plane ? sigma[plane - 1] : 3.0f;
+        } else if (sigma[plane] < 0.0f) {
+            return set_error("\"sigma\" must be non-negative");
+        }
+        d->process[plane] = sigma[plane] >=
+            std::numeric_limits<float>::epsilon();
+    }
+    for (int plane = 0; plane < 3; ++plane) {
+        sigma[plane] *= (3.0f / 4.0f) / 255.0f * 64.0f *
+            (d->final_ ? 1.0f : 2.7f);
+    }
+
+    int block_step[3];
+    int bm_range[3];
+    int ps_num[3];
+    int ps_range[3];
+    for (int plane = 0; plane < 3; ++plane) {
+        block_step[plane] = int64ToIntS(
+            vsapi->propGetInt(in, "block_step", plane, &error));
+        if (error) {
+            block_step[plane] = plane ? block_step[plane - 1] : 8;
+        } else if (block_step[plane] <= 0 || block_step[plane] > 8) {
+            return set_error("\"block_step\" must be in range [1, 8]");
+        }
+
+        bm_range[plane] = int64ToIntS(
+            vsapi->propGetInt(in, "bm_range", plane, &error));
+        if (error) {
+            bm_range[plane] = plane ? bm_range[plane - 1] : 9;
+        } else if (bm_range[plane] <= 0) {
+            return set_error("\"bm_range\" must be positive");
+        }
+
+        ps_num[plane] = int64ToIntS(
+            vsapi->propGetInt(in, "ps_num", plane, &error));
+        if (error) {
+            ps_num[plane] = plane ? ps_num[plane - 1] : 2;
+        } else if (ps_num[plane] <= 0 || ps_num[plane] > 8) {
+            return set_error("\"ps_num\" must be in range [1, 8]");
+        }
+
+        ps_range[plane] = int64ToIntS(
+            vsapi->propGetInt(in, "ps_range", plane, &error));
+        if (error) {
+            ps_range[plane] = plane ? ps_range[plane - 1] : 4;
+        } else if (ps_range[plane] <= 0) {
+            return set_error("\"ps_range\" must be positive");
+        }
+    }
+
+    d->radius = int64ToIntS(vsapi->propGetInt(in, "radius", 0, &error));
+    if (error) {
+        d->radius = 0;
+    }
+    if (d->radius <= 0) {
+        return set_error("\"radius\" must be positive");
+    }
+    if (d->radius >
+        (std::numeric_limits<int>::max() - chunk_size) / 4) {
+        return set_error("\"radius\" is too large for rolling temporal processing");
+    }
+    d->chunk_size = chunk_size;
+
+    d->chroma = !!vsapi->propGetInt(in, "chroma", 0, &error);
+    if (error) {
+        d->chroma = false;
+    }
+    if (d->chroma && d->vi->format->id != pfYUV444PS) {
+        return set_error("clip format must be YUV444 when \"chroma\" is true");
+    }
+
+    d->device_id = int64ToIntS(
+        vsapi->propGetInt(in, "device_id", 0, &error));
+    if (error) {
+        d->device_id = 0;
+    }
+    int device_count;
+    checkError(cudaGetDeviceCount(&device_count));
+    if (d->device_id < 0 || d->device_id >= device_count) {
+        return set_error(
+            "invalid device ID (" + std::to_string(d->device_id) + ")");
+    }
+    checkError(cudaSetDevice(d->device_id));
+
+    const float extractor = [&]() {
+        const int exponent = int64ToIntS(
+            vsapi->propGetInt(in, "extractor_exp", 0, &error));
+        if (error) {
+            return 0.0f;
+        }
+        return exponent ? std::ldexp(1.0f, exponent) : 0.0f;
+    }();
+
+    int process_mask = 0;
+    for (int plane = 0; plane < d->vi->format->numPlanes; ++plane) {
+        process_mask |= static_cast<int>(d->process[plane]) << plane;
+    }
+
+    if (process_mask) {
+        const int source_width = chunk_size + 4 * d->radius;
+        const int temporal_width = 2 * d->radius + 1;
+        const int clips = d->final_ ? 2 : 1;
+        const int max_width = d->process[0] ? width :
+            width >> d->vi->format->subSamplingW;
+        const int max_height = d->process[0] ? height :
+            height >> d->vi->format->subSamplingH;
+        const int graph_planes = d->chroma ? 3 : 1;
+        if (max_width > std::numeric_limits<int>::max() - 255) {
+            return set_error("clip width exceeds CUDA grid limits");
+        }
+        if (max_height > 65535) {
+            return set_error("clip height exceeds CUDA grid limits");
+        }
+
+        size_t min_temporal_stride;
+        size_t max_source_offset;
+        size_t max_scratch_offset;
+        if (
+            !checked_mul(static_cast<size_t>(max_width), max_height,
+                min_temporal_stride) ||
+            !checked_mul(min_temporal_stride, source_width,
+                max_source_offset) ||
+            !checked_mul(min_temporal_stride, temporal_width * 2LL,
+                max_scratch_offset) ||
+            !checked_mul(max_source_offset, graph_planes,
+                max_source_offset) ||
+            !checked_mul(max_scratch_offset, graph_planes,
+                max_scratch_offset) ||
+            max_source_offset > std::numeric_limits<int>::max() ||
+            max_scratch_offset > std::numeric_limits<int>::max()) {
+            return set_error("clip dimensions exceed CUDA indexing limits");
+        }
+
+        if (d->chroma) {
+            size_t plane_source_rows;
+            if (
+                !checked_mul(static_cast<size_t>(source_width), height,
+                    plane_source_rows) ||
+                !checked_mul(plane_source_rows, clips * 3LL,
+                    d->source_rows) ||
+                !checked_mul(static_cast<size_t>(chunk_size), 6LL * height,
+                d->output_rows)) {
+                return set_error("rolling buffer size overflow");
+            }
+            for (int plane = 0; plane < 3; ++plane) {
+                d->output_plane_rows[plane] =
+                    static_cast<size_t>(plane) * 2 * height;
+                d->output_step_rows[plane] = 6LL * height;
+            }
+        } else {
+            for (int plane = 0; plane < d->vi->format->numPlanes; ++plane) {
+                if (!d->process[plane]) {
+                    continue;
+                }
+                const int plane_height = plane ?
+                    height >> d->vi->format->subSamplingH : height;
+                size_t source_rows;
+                size_t output_rows;
+                size_t updated;
+                if (
+                    !checked_mul(static_cast<size_t>(clips) * source_width,
+                        plane_height, source_rows) ||
+                    !checked_mul(static_cast<size_t>(chunk_size) * 2,
+                        plane_height, output_rows) ||
+                    !checked_add(d->source_rows, source_rows, updated)) {
+                    return set_error("rolling buffer size overflow");
+                }
+                d->source_rows = updated;
+                d->output_plane_rows[plane] = d->output_rows;
+                d->output_step_rows[plane] = 2LL * plane_height;
+                if (!checked_add(d->output_rows, output_rows, updated)) {
+                    return set_error("rolling buffer size overflow");
+                }
+                d->output_rows = updated;
+            }
+        }
+
+        size_t scratch_rows;
+        if (!checked_mul(
+            static_cast<size_t>(graph_planes) * temporal_width * 2,
+            max_height, scratch_rows)) {
+            return set_error("rolling scratch size overflow");
+        }
+
+        size_t pitch;
+        checkError(cudaMallocPitch(
+            &d->resource.d_src.data, &pitch,
+            static_cast<size_t>(max_width) * sizeof(float), d->source_rows));
+        if (
+            pitch > static_cast<size_t>(std::numeric_limits<int>::max()) ||
+            pitch % sizeof(float)) {
+            return set_error("device pitch exceeds the supported range");
+        }
+        d->d_pitch = static_cast<int>(pitch);
+        const size_t d_stride = pitch / sizeof(float);
+        size_t temporal_stride;
+        size_t source_offset;
+        size_t scratch_offset;
+        if (
+            !checked_mul(d_stride, max_height, temporal_stride) ||
+            !checked_mul(temporal_stride, source_width, source_offset) ||
+            !checked_mul(temporal_stride, temporal_width * 2LL,
+                scratch_offset) ||
+            !checked_mul(source_offset, graph_planes, source_offset) ||
+            !checked_mul(scratch_offset, graph_planes, scratch_offset) ||
+            source_offset > std::numeric_limits<int>::max() ||
+            scratch_offset > std::numeric_limits<int>::max()) {
+            return set_error("device pitch exceeds CUDA indexing limits");
+        }
+
+        size_t source_bytes;
+        size_t scratch_bytes;
+        size_t output_bytes;
+        if (
+            !checked_mul(d->source_rows, pitch, source_bytes) ||
+            !checked_mul(scratch_rows, pitch, scratch_bytes) ||
+            !checked_mul(d->output_rows, pitch, output_bytes)) {
+            return set_error("rolling allocation size overflow");
+        }
+
+        checkError(cudaMalloc(&d->resource.d_scratch.data, scratch_bytes));
+        checkError(cudaMalloc(&d->resource.d_accum.data, output_bytes));
+        checkError(cudaMallocHost(&d->resource.h_src.data, source_bytes));
+        checkError(cudaMallocHost(&d->resource.h_output.data, output_bytes));
+
+        const size_t params_count = 1 + static_cast<size_t>(chunk_size) +
+            2 * static_cast<size_t>(d->radius);
+        size_t params_bytes;
+        if (!checked_mul(params_count, sizeof(int), params_bytes)) {
+            return set_error("rolling parameter size overflow");
+        }
+        checkError(cudaMalloc(&d->resource.d_params.data, params_bytes));
+        checkError(cudaMallocHost(&d->resource.h_params.data, params_bytes));
+        checkError(cudaStreamCreateWithFlags(
+            &d->resource.stream.data, cudaStreamNonBlocking));
+
+        const auto graph = get_rolling_graphexec(
+            d->resource.d_accum, d->resource.d_scratch,
+            d->resource.d_src, d->resource.h_src, d->resource.h_output,
+            d->resource.d_params, d->resource.h_params,
+            width, height, static_cast<int>(d_stride),
+            sigma, block_step, bm_range, ps_num, ps_range,
+            d->radius, chunk_size, process_mask,
+            d->vi->format->numPlanes,
+            d->vi->format->subSamplingW, d->vi->format->subSamplingH,
+            d->chroma, d->final_, extractor);
+        if (std::holds_alternative<std::string>(graph)) {
+            return set_error(std::get<std::string>(graph));
+        }
+        d->resource.graphexec = std::get<cudaGraphExec_t>(graph);
+    }
+
+    vsapi->createFilter(
+        in, out, "BM3Dv2 rolling",
+        RollingInit, RollingGetFrame, RollingFree,
+        fmParallelRequests, 0, d.release(), core);
+    } catch (const std::bad_alloc &) {
+        vsapi->setError(out, "BM3Dv2 rolling: memory allocation failed");
+    }
+}
+
 struct VAggregateData {
     VSNodeRef * node;
 
@@ -1064,10 +1680,98 @@ static void VS_CC VAggregateCreate(
         fmParallel, 0, d.release(), core);
 }
 
+static VSMap * copy_bm3d_args(
+    const VSMap * in, const VSAPI * vsapi
+) noexcept {
+    VSMap * result = vsapi->createMap();
+    for (int key_index = 0; key_index < vsapi->propNumKeys(in); ++key_index) {
+        const char * key = vsapi->propGetKey(in, key_index);
+        if (
+            std::string_view { key } == "temporal_mode" ||
+            std::string_view { key } == "rolling_chunk") {
+            continue;
+        }
+        const int elements = vsapi->propNumElements(in, key);
+        for (int index = 0; index < elements; ++index) {
+            switch (vsapi->propGetType(in, key)) {
+            case ptInt:
+                vsapi->propSetInt(
+                    result, key,
+                    vsapi->propGetInt(in, key, index, nullptr), paAppend);
+                break;
+            case ptFloat:
+                vsapi->propSetFloat(
+                    result, key,
+                    vsapi->propGetFloat(in, key, index, nullptr), paAppend);
+                break;
+            case ptNode: {
+                VSNodeRef * node = vsapi->propGetNode(in, key, index, nullptr);
+                vsapi->propSetNode(result, key, node, paAppend);
+                vsapi->freeNode(node);
+                break;
+            }
+            default:
+                break;
+            }
+        }
+    }
+    return result;
+}
+
 static void VS_CC BM3Dv2Create(
     const VSMap *in, VSMap *out, void *userData,
     VSCore *core, const VSAPI *vsapi
 ) {
+    int error;
+    std::string temporal_mode { "fused" };
+    if (vsapi->propNumElements(in, "temporal_mode") >= 0) {
+        const char * value = vsapi->propGetData(
+            in, "temporal_mode", 0, &error);
+        const int size = vsapi->propGetDataSize(
+            in, "temporal_mode", 0, &error);
+        if (error) {
+            vsapi->setError(out, "BM3Dv2: \"temporal_mode\" must be a string");
+            return;
+        }
+        temporal_mode.assign(value, size);
+    }
+    if (
+        temporal_mode != "fused" && temporal_mode != "legacy" &&
+        temporal_mode != "rolling") {
+        vsapi->setError(
+            out,
+            "BM3Dv2: \"temporal_mode\" must be one of fused, legacy, or rolling");
+        return;
+    }
+
+    const bool chunk_supplied =
+        vsapi->propNumElements(in, "rolling_chunk") >= 0;
+    if (chunk_supplied && temporal_mode != "rolling") {
+        vsapi->setError(
+            out,
+            "BM3Dv2: \"rolling_chunk\" is valid only when temporal_mode is rolling");
+        return;
+    }
+    int rolling_chunk = 16;
+    if (chunk_supplied) {
+        rolling_chunk = int64ToIntS(
+            vsapi->propGetInt(in, "rolling_chunk", 0, &error));
+        if (error || rolling_chunk < 1 || rolling_chunk > 64) {
+            vsapi->setError(
+                out, "BM3Dv2: \"rolling_chunk\" must be in range [1, 64]");
+            return;
+        }
+    }
+
+    int radius = int64ToIntS(vsapi->propGetInt(in, "radius", 0, &error));
+    if (error) {
+        radius = 0;
+    }
+    if (temporal_mode == "rolling" && radius <= 0) {
+        vsapi->setError(
+            out, "BM3Dv2: rolling temporal mode requires radius greater than zero");
+        return;
+    }
 
     std::array<bool, 3> process;
     process.fill(true);
@@ -1088,28 +1792,62 @@ static void VS_CC BM3Dv2Create(
     bool skip = true;
     auto src = vsapi->propGetNode(in, "clip", 0, nullptr);
     auto src_vi = vsapi->getVideoInfo(src);
-    for (int i = 0; i < src_vi->format->numPlanes; ++i) {
+    const int source_planes = src_vi->format->numPlanes;
+    for (int i = 0; i < source_planes; ++i) {
         skip &= !process[i];
     }
-    if (skip) {
+    if (skip && temporal_mode != "rolling") {
         vsapi->propSetNode(out, "clip", src, paReplace);
         vsapi->freeNode(src);
         return ;
     }
 
-    int error;
-    int radius = int64ToIntS(vsapi->propGetInt(in, "radius", 0, &error));
-    if (error) {
-        radius = 0;
-    }
     if (radius > 0) {
         vsapi->freeNode(src);
-        BM3DCreateImpl(in, out, userData, core, vsapi, true);
+        if (temporal_mode == "fused") {
+            BM3DCreateImpl(in, out, userData, core, vsapi, true);
+        } else if (temporal_mode == "rolling") {
+            RollingCreate(in, out, rolling_chunk, core, vsapi);
+        } else {
+            auto plugin = vsapi->getPluginById(PLUGIN_ID, core);
+            VSMap * bm3d_in = copy_bm3d_args(in, vsapi);
+
+            auto map = vsapi->invoke(plugin, "BM3D", bm3d_in);
+            vsapi->freeMap(bm3d_in);
+            if (auto invoke_error = vsapi->getError(map); invoke_error) {
+                vsapi->setError(out, invoke_error);
+                vsapi->freeMap(map);
+                return;
+            }
+
+            VSNodeRef * original = vsapi->propGetNode(in, "clip", 0, nullptr);
+            vsapi->propSetNode(map, "src", original, paReplace);
+            vsapi->freeNode(original);
+            for (int plane = 0; plane < source_planes; ++plane) {
+                if (process[plane]) {
+                    vsapi->propSetInt(map, "planes", plane, paAppend);
+                }
+            }
+
+            auto aggregate = vsapi->invoke(plugin, "VAggregate", map);
+            vsapi->freeMap(map);
+            if (auto invoke_error = vsapi->getError(aggregate); invoke_error) {
+                vsapi->setError(out, invoke_error);
+                vsapi->freeMap(aggregate);
+                return;
+            }
+            auto node = vsapi->propGetNode(aggregate, "clip", 0, nullptr);
+            vsapi->freeMap(aggregate);
+            vsapi->propSetNode(out, "clip", node, paReplace);
+            vsapi->freeNode(node);
+        }
         return;
     }
 
     auto plugin = vsapi->getPluginById(PLUGIN_ID, core);
-    auto map = vsapi->invoke(plugin, "BM3D", in);
+    VSMap * bm3d_in = copy_bm3d_args(in, vsapi);
+    auto map = vsapi->invoke(plugin, "BM3D", bm3d_in);
+    vsapi->freeMap(bm3d_in);
     if (auto error = vsapi->getError(map); error) {
         vsapi->setError(out, error);
         vsapi->freeMap(map);
@@ -1185,5 +1923,22 @@ VS_EXTERNAL_API(void) VapourSynthPluginInit(
         "planes:int[];",
         VAggregateCreate, nullptr, plugin);
 
-    registerFunc("BM3Dv2", bm3d_args, BM3Dv2Create, nullptr, plugin);
+    constexpr auto bm3dv2_args {
+        "clip:clip;"
+        "ref:clip:opt;"
+        "sigma:float[]:opt;"
+        "block_step:int[]:opt;"
+        "bm_range:int[]:opt;"
+        "radius:int:opt;"
+        "ps_num:int[]:opt;"
+        "ps_range:int[]:opt;"
+        "chroma:int:opt;"
+        "device_id:int:opt;"
+        "fast:int:opt;"
+        "extractor_exp:int:opt;"
+        "zero_init:int:opt;"
+        "temporal_mode:data:opt;"
+        "rolling_chunk:int:opt;"
+    };
+    registerFunc("BM3Dv2", bm3dv2_args, BM3Dv2Create, nullptr, plugin);
 }

--- a/source/source.cpp
+++ b/source/source.cpp
@@ -33,6 +33,7 @@
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include <cuda_runtime.h>
@@ -44,6 +45,16 @@ using namespace std::string_literals;
 
 extern cudaGraphExec_t get_graphexec(
     float * d_res, float * d_src, float * h_res,
+    int width, int height, int stride,
+    float sigma, int block_step, int bm_range,
+    int radius, int ps_num, int ps_range,
+    bool chroma, float sigma_u, float sigma_v,
+    bool final_, float extractor
+) noexcept;
+
+extern std::variant<cudaGraphExec_t, std::string> get_fused_graphexec(
+    float * d_res, float * d_src, float * h_res,
+    int * d_params, int * h_params,
     int width, int height, int stride,
     float sigma, int block_step, int bm_range,
     int radius, int ps_num, int ps_range,
@@ -157,9 +168,11 @@ struct BM3DData {
     bool chroma;
     bool process[3]; // sigma != 0
     bool final_;
+    bool fused;
     bool zero_init;
 
     int d_pitch;
+    size_t params_offset;
     int device_id;
 
     ticket_semaphore semaphore;
@@ -172,15 +185,12 @@ static inline void Aggregation(
     const float * VS_RESTRICT srcp, int src_stride,
     int width, int height
 ) noexcept {
-
     const float * wdst = srcp;
     const float * weight = &srcp[height * src_stride];
-
     for (int y = 0; y < height; ++y) {
         for (int x = 0; x < width; ++x) {
             dstp[x] = wdst[x] / weight[x];
         }
-
         dstp += dst_stride;
         wdst += src_stride;
         weight += src_stride;
@@ -194,7 +204,7 @@ static void VS_CC BM3DInit(
 
     BM3DData * d = static_cast<BM3DData *>(*instanceData);
 
-    if (d->radius) {
+    if (d->radius && !d->fused) {
         VSVideoInfo vi = *d->vi;
         vi.height *= 2 * (2 * d->radius + 1);
         vsapi->setVideoInfo(&vi, 1, node);
@@ -211,8 +221,11 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
     auto d = static_cast<BM3DData *>(*instanceData);
 
     if (activationReason == arInitial) {
-        int start_frame = std::max(n - d->radius, 0);
-        int end_frame = std::min(n + d->radius, d->vi->numFrames - 1);
+        int64_t request_radius = d->fused ? 2LL * d->radius : d->radius;
+        int start_frame = static_cast<int>(
+            std::max<int64_t>(static_cast<int64_t>(n) - request_radius, 0));
+        int end_frame = static_cast<int>(std::min<int64_t>(
+            static_cast<int64_t>(n) + request_radius, d->vi->numFrames - 1));
 
         for (int i = start_frame; i <= end_frame; ++i) {
             vsapi->requestFrameFilter(i, d->node, frameCtx);
@@ -234,7 +247,14 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
         int radius = d->radius;
         int temporal_width = 2 * radius + 1;
         bool final_ = d->final_;
-        int num_input_frames = temporal_width * (final_ ? 2 : 1); // including ref
+        bool fused = d->fused;
+        int64_t request_radius = fused ? 2LL * radius : radius;
+        int start_frame = static_cast<int>(
+            std::max<int64_t>(static_cast<int64_t>(n) - request_radius, 0));
+        int end_frame = static_cast<int>(std::min<int64_t>(
+            static_cast<int64_t>(n) + request_radius, d->vi->numFrames - 1));
+        int input_width = fused ? end_frame - start_frame + 1 : temporal_width;
+        int num_input_frames = input_width * (final_ ? 2 : 1); // including ref
 
         using freeFrame_t = decltype(vsapi->freeFrame);
         const std::vector srcs = [&](){
@@ -243,8 +263,9 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
             temp.reserve(num_input_frames);
 
             if (final_) {
-                for (int i = -radius; i <= radius; ++i) {
-                    int clamped_n = std::clamp(n + i, 0, d->vi->numFrames - 1);
+                for (int i = 0; i < input_width; ++i) {
+                    int clamped_n = fused ? start_frame + i :
+                        std::clamp(n - radius + i, 0, d->vi->numFrames - 1);
                     temp.emplace_back(
                         vsapi->getFrameFilter(clamped_n, d->ref_node, frameCtx),
                         vsapi->freeFrame
@@ -252,8 +273,9 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
                 }
             }
 
-            for (int i = -radius; i <= radius; ++i) {
-                int clamped_n = std::clamp(n + i, 0, d->vi->numFrames - 1);
+            for (int i = 0; i < input_width; ++i) {
+                int clamped_n = fused ? start_frame + i :
+                    std::clamp(n - radius + i, 0, d->vi->numFrames - 1);
                 temp.emplace_back(
                     vsapi->getFrameFilter(clamped_n, d->node, frameCtx),
                     vsapi->freeFrame
@@ -263,10 +285,11 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
             return temp;
         }();
 
-        const VSFrameRef * src = srcs[radius + (final_ ? temporal_width : 0)].get();
+        int center_index = fused ? n - start_frame : radius;
+        const VSFrameRef * src = srcs[center_index + (final_ ? input_width : 0)].get();
 
         std::unique_ptr<VSFrameRef, const freeFrame_t &> dst { nullptr, vsapi->freeFrame };
-        if (radius) {
+        if (radius && !fused) {
             dst.reset(
                 vsapi->newVideoFrame(
                     d->vi->format, d->vi->width,
@@ -330,9 +353,9 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
             float * h_src = h_res;
             for (int outer = 0; outer < (final_ ? 2 : 1); ++outer) {
                 for (int i = 0; i < std::ssize(d->process); ++i) {
-                    for (int j = 0; j < temporal_width; ++j) {
+                    for (int j = 0; j < input_width; ++j) {
                         if (i == 0 || d->process[i]) {
-                            auto current_src = srcs[j + outer * temporal_width].get();
+                            auto current_src = srcs[j + outer * input_width].get();
 
                             vs_bitblt(
                                 h_src, d_pitch,
@@ -342,6 +365,22 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
                         }
                         h_src += d_stride * height;
                     }
+                    if (fused) {
+                        h_src += d_stride * height * (4 * radius + 1 - input_width);
+                    }
+                }
+            }
+
+            if (fused) {
+                int * params = reinterpret_cast<int *>(
+                    reinterpret_cast<char *>(h_res) + d->params_offset);
+                params[0] = input_width;
+                for (int center = 0; center < temporal_width; ++center) {
+                    int center_frame = static_cast<int>(std::clamp<int64_t>(
+                        static_cast<int64_t>(n) - radius + center,
+                        0, d->vi->numFrames - 1));
+                    params[1 + 2 * center] = center_frame - start_frame;
+                    params[2 + 2 * center] = n - center_frame + radius;
                 }
             }
 
@@ -352,27 +391,25 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
             float * h_dst = h_res;
             for (int plane = 0; plane < std::ssize(d->process); ++plane) {
                 if (!d->process[plane]) {
-                    h_dst += d_stride * height * 2 * temporal_width;
+                    h_dst += d_stride * height * 2 * (fused ? 1 : temporal_width);
                     continue;
                 }
 
                 float * dstp = reinterpret_cast<float *>(
                     vsapi->getWritePtr(dst.get(), plane));
 
-                if (radius) {
+                if (radius && !fused) {
                     vs_bitblt(
                         dstp, s_pitch, h_dst, d_pitch,
                         width_bytes, height * 2 * temporal_width
                     );
+                } else if (fused) {
+                    vs_bitblt(dstp, s_pitch, h_dst, d_pitch, width_bytes, height);
                 } else {
-                    Aggregation(
-                        dstp, s_stride,
-                        h_dst, d_stride,
-                        width, height
-                    );
+                    Aggregation(dstp, s_stride, h_dst, d_stride, width, height);
                 }
 
-                h_dst += d_stride * height * 2 * temporal_width;
+                h_dst += d_stride * height * 2 * (fused ? 1 : temporal_width);
             }
         } else { // !d->chroma
             for (int plane = 0; plane < d->vi->format->numPlanes; plane++) {
@@ -396,6 +433,22 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
                         width_bytes, height
                     );
                     h_src += d_stride * height;
+                    if (fused && (i + 1) % input_width == 0) {
+                        h_src += d_stride * height * (4 * radius + 1 - input_width);
+                    }
+                }
+
+                if (fused) {
+                    int * params = reinterpret_cast<int *>(
+                        reinterpret_cast<char *>(h_res) + d->params_offset);
+                    params[0] = input_width;
+                    for (int center = 0; center < temporal_width; ++center) {
+                        int center_frame = static_cast<int>(std::clamp<int64_t>(
+                            static_cast<int64_t>(n) - radius + center,
+                            0, d->vi->numFrames - 1));
+                        params[1 + 2 * center] = center_frame - start_frame;
+                        params[2 + 2 * center] = n - center_frame + radius;
+                    }
                 }
 
                 checkError(cudaGraphLaunch(graphexec, stream));
@@ -405,17 +458,15 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
                 float * dstp = reinterpret_cast<float *>(
                     vsapi->getWritePtr(dst.get(), plane));
 
-                if (radius) {
+                if (radius && !fused) {
                     vs_bitblt(
                         dstp, s_pitch, h_res, d_pitch,
                         width_bytes, height * 2 * temporal_width
                     );
+                } else if (fused) {
+                    vs_bitblt(dstp, s_pitch, h_res, d_pitch, width_bytes, height);
                 } else {
-                    Aggregation(
-                        dstp, s_stride,
-                        h_res, d_stride,
-                        width, height
-                    );
+                    Aggregation(dstp, s_stride, h_res, d_stride, width, height);
                 }
             }
         }
@@ -425,7 +476,7 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
         d->resources_lock.unlock();
         d->semaphore.release();
 
-        if (radius) {
+        if (radius && !fused) {
             VSMap * dst_prop { vsapi->getFramePropsRW(dst.get()) };
 
             vsapi->propSetInt(dst_prop, "BM3D_V_radius", d->radius, paReplace);
@@ -454,9 +505,9 @@ static void VS_CC BM3DFree(
     delete d;
 }
 
-static void VS_CC BM3DCreate(
+static void BM3DCreateImpl(
     const VSMap *in, VSMap *out, void *userData,
-    VSCore *core, const VSAPI *vsapi
+    VSCore *core, const VSAPI *vsapi, bool fused
 ) noexcept {
 
     auto d { std::make_unique<BM3DData>() };
@@ -499,6 +550,7 @@ static void VS_CC BM3DCreate(
         final_ = true;
     }
     d->final_ = final_;
+    d->fused = fused;
 
     float sigma[3];
     for (int i = 0; i < std::ssize(sigma); ++i) {
@@ -555,6 +607,9 @@ static void VS_CC BM3DCreate(
     }();
     if (radius < 0) {
         return set_error("\"radius\" must be non-negative");
+    }
+    if (fused && radius > (std::numeric_limits<int>::max() - 1) / 4) {
+        return set_error("\"radius\" is too large for fused temporal processing");
     }
     d->radius = radius;
 
@@ -642,8 +697,32 @@ static void VS_CC BM3DCreate(
         int max_width { d->process[0] ? width : width >> d->vi->format->subSamplingW };
         int max_height { d->process[0] ? height : height >> d->vi->format->subSamplingH };
 
-        int num_planes { chroma ? 3 : 1 };
-        int temporal_width = 2 * radius + 1;
+        const int num_planes { chroma ? 3 : 1 };
+        const int temporal_width = 2 * radius + 1;
+        const int source_temporal_width = fused ? 4 * radius + 1 : temporal_width;
+        if (fused) {
+            const size_t min_temporal_stride =
+                static_cast<size_t>(max_width) * max_height;
+            const size_t max_kernel_offset = std::numeric_limits<int>::max();
+            if (
+                min_temporal_stride > max_kernel_offset ||
+                static_cast<size_t>(source_temporal_width) >
+                    max_kernel_offset / min_temporal_stride ||
+                static_cast<size_t>(num_planes) > max_kernel_offset /
+                    (min_temporal_stride * source_temporal_width)) {
+                return set_error("\"radius\" is too large for the clip dimensions");
+            }
+        }
+        const size_t source_rows = static_cast<size_t>(final_ ? 2 : 1) *
+            static_cast<size_t>(num_planes) * source_temporal_width * max_height;
+        const size_t result_rows = static_cast<size_t>(num_planes) *
+            temporal_width * 2 * max_height;
+        const size_t buffer_rows = std::max(source_rows, result_rows);
+        const size_t params_size = fused ?
+            (1 + 2 * static_cast<size_t>(temporal_width)) * sizeof(int) : 0;
+        const size_t min_pitch = static_cast<size_t>(max_width) * sizeof(float);
+        const size_t params_rows = fused ?
+            (params_size + min_pitch - 1) / min_pitch : 0;
         size_t d_pitch;
         int d_stride;
         for (int i = 0; i < num_copy_engines; ++i) {
@@ -651,21 +730,38 @@ static void VS_CC BM3DCreate(
             if (i == 0) {
                 checkError(cudaMallocPitch(
                     &d_src.data, &d_pitch, max_width * sizeof(float),
-                    (final_ ? 2 : 1) * num_planes * temporal_width * max_height));
+                    fused ? buffer_rows + params_rows : source_rows));
+                if (d_pitch >
+                    static_cast<size_t>(std::numeric_limits<int>::max())) {
+                    return set_error("device pitch exceeds the supported range");
+                }
                 d_stride = static_cast<int>(d_pitch / sizeof(float));
+                if (fused) {
+                    const size_t temporal_stride =
+                        static_cast<size_t>(max_height) * d_stride;
+                    const size_t max_kernel_offset = std::numeric_limits<int>::max();
+                    if (
+                        temporal_stride > max_kernel_offset ||
+                        static_cast<size_t>(source_temporal_width) >
+                            max_kernel_offset / temporal_stride ||
+                        static_cast<size_t>(num_planes) > max_kernel_offset /
+                            (temporal_stride * source_temporal_width)) {
+                        return set_error("\"radius\" is too large for the device pitch");
+                    }
+                }
                 d->d_pitch = static_cast<int>(d_pitch);
+                d->params_offset = buffer_rows * d_pitch;
             } else {
                 checkError(cudaMalloc(&d_src.data,
-                    (final_ ? 2 : 1) * num_planes * temporal_width * max_height * d_pitch));
+                    fused ? buffer_rows * d_pitch + params_size : source_rows * d_pitch));
             }
 
             Resource<float *, cudaFree> d_res {};
-            checkError(cudaMalloc(&d_res.data,
-                num_planes * temporal_width * 2 * max_height * d_pitch));
+            checkError(cudaMalloc(&d_res.data, result_rows * d_pitch));
 
             Resource<float *, cudaFreeHost> h_res {};
             checkError(cudaMallocHost(&h_res.data,
-                num_planes * temporal_width * 2 * max_height * d_pitch));
+                buffer_rows * d_pitch + params_size));
 
             Resource<cudaStream_t, cudaStreamDestroy> stream {};
             checkError(cudaStreamCreateWithFlags(&stream.data,
@@ -673,14 +769,28 @@ static void VS_CC BM3DCreate(
 
             std::array<Resource<cudaGraphExec_t, cudaGraphExecDestroy>, 3> graphexecs {};
             if (d->chroma) {
-                graphexecs[0] = get_graphexec(
-                    d_res, d_src, h_res,
-                    width, height, d_stride,
-                    sigma[0], block_step[0], bm_range[0],
-                    radius, ps_num[0], ps_range[0],
-                    true, sigma[1], sigma[2],
-                    final_, extractor
-                );
+                if (fused) {
+                    const auto result = get_fused_graphexec(
+                        d_res, d_src, h_res,
+                        reinterpret_cast<int *>(reinterpret_cast<char *>(d_src.data) + d->params_offset),
+                        reinterpret_cast<int *>(reinterpret_cast<char *>(h_res.data) + d->params_offset),
+                        width, height, d_stride,
+                        sigma[0], block_step[0], bm_range[0],
+                        radius, ps_num[0], ps_range[0],
+                        true, sigma[1], sigma[2], final_, extractor);
+                    if (std::holds_alternative<cudaGraphExec_t>(result)) {
+                        graphexecs[0] = std::get<cudaGraphExec_t>(result);
+                    } else {
+                        return set_error(std::get<std::string>(result));
+                    }
+                } else {
+                    graphexecs[0] = get_graphexec(
+                        d_res, d_src, h_res,
+                        width, height, d_stride,
+                        sigma[0], block_step[0], bm_range[0],
+                        radius, ps_num[0], ps_range[0],
+                        true, sigma[1], sigma[2], final_, extractor);
+                }
             } else {
                 auto subsamplingW = d->vi->format->subSamplingW;
                 auto subsamplingH = d->vi->format->subSamplingH;
@@ -690,14 +800,28 @@ static void VS_CC BM3DCreate(
                         int plane_width { plane == 0 ? width : width >> subsamplingW };
                         int plane_height { plane == 0 ? height : height >> subsamplingH };
 
-                        graphexecs[plane] = get_graphexec(
-                            d_res, d_src, h_res,
-                            plane_width, plane_height, d_stride,
-                            sigma[plane], block_step[plane], bm_range[plane],
-                            radius, ps_num[plane], ps_range[plane],
-                            false, 0.0f, 0.0f,
-                            final_, extractor
-                        );
+                        if (fused) {
+                            const auto result = get_fused_graphexec(
+                                d_res, d_src, h_res,
+                                reinterpret_cast<int *>(reinterpret_cast<char *>(d_src.data) + d->params_offset),
+                                reinterpret_cast<int *>(reinterpret_cast<char *>(h_res.data) + d->params_offset),
+                                plane_width, plane_height, d_stride,
+                                sigma[plane], block_step[plane], bm_range[plane],
+                                radius, ps_num[plane], ps_range[plane],
+                                false, 0.0f, 0.0f, final_, extractor);
+                            if (std::holds_alternative<cudaGraphExec_t>(result)) {
+                                graphexecs[plane] = std::get<cudaGraphExec_t>(result);
+                            } else {
+                                return set_error(std::get<std::string>(result));
+                            }
+                        } else {
+                            graphexecs[plane] = get_graphexec(
+                                d_res, d_src, h_res,
+                                plane_width, plane_height, d_stride,
+                                sigma[plane], block_step[plane], bm_range[plane],
+                                radius, ps_num[plane], ps_range[plane],
+                                false, 0.0f, 0.0f, final_, extractor);
+                        }
                     }
                 }
             }
@@ -713,10 +837,17 @@ static void VS_CC BM3DCreate(
     }
 
     vsapi->createFilter(
-        in, out, "BM3D",
+        in, out, fused ? "BM3Dv2" : "BM3D",
         BM3DInit, BM3DGetFrame, BM3DFree,
         fmParallel, 0, d.release(), core
     );
+}
+
+static void VS_CC BM3DCreate(
+    const VSMap *in, VSMap *out, void *userData,
+    VSCore *core, const VSAPI *vsapi
+) noexcept {
+    BM3DCreateImpl(in, out, userData, core, vsapi, false);
 }
 
 struct VAggregateData {
@@ -884,17 +1015,42 @@ static void VS_CC VAggregateCreate(
 
     auto d { std::make_unique<VAggregateData>() };
 
+    const auto set_error = [&](const std::string & error_message) {
+        vsapi->setError(out, ("VAggregate: " + error_message).c_str());
+        if (d->src_node) {
+            vsapi->freeNode(d->src_node);
+        }
+        if (d->node) {
+            vsapi->freeNode(d->node);
+        }
+    };
+
     d->node = vsapi->propGetNode(in, "clip", 0, nullptr);
     auto vi = vsapi->getVideoInfo(d->node);
     d->src_node = vsapi->propGetNode(in, "src", 0, nullptr);
     d->src_vi = vsapi->getVideoInfo(d->src_node);
+
+    const int num_planes = d->src_vi->format->numPlanes;
+    if (num_planes > static_cast<int>(d->process.size())) {
+        return set_error("source clip has too many planes");
+    }
 
     d->radius = (vi->height / d->src_vi->height - 2) / 4;
 
     d->process.fill(false);
     int num_planes_args = vsapi->propNumElements(in, "planes");
     for (int i = 0; i < num_planes_args; ++i) {
-        int plane = vsapi->propGetInt(in, "planes", i, nullptr);
+        int error;
+        int plane = int64ToIntS(vsapi->propGetInt(in, "planes", i, &error));
+        if (error) {
+            return set_error("\"planes\" must contain only integers");
+        }
+        if (plane < 0 || plane >= num_planes) {
+            return set_error("\"planes\" contains an out-of-range plane index");
+        }
+        if (d->process[plane]) {
+            return set_error("\"planes\" contains a duplicate plane index");
+        }
         d->process[plane] = true;
     }
 
@@ -941,6 +1097,17 @@ static void VS_CC BM3Dv2Create(
         return ;
     }
 
+    int error;
+    int radius = int64ToIntS(vsapi->propGetInt(in, "radius", 0, &error));
+    if (error) {
+        radius = 0;
+    }
+    if (radius > 0) {
+        vsapi->freeNode(src);
+        BM3DCreateImpl(in, out, userData, core, vsapi, true);
+        return;
+    }
+
     auto plugin = vsapi->getPluginById(PLUGIN_ID, core);
     auto map = vsapi->invoke(plugin, "BM3D", in);
     if (auto error = vsapi->getError(map); error) {
@@ -950,11 +1117,6 @@ static void VS_CC BM3Dv2Create(
         return ;
     }
 
-    int error;
-    int radius = vsapi->propGetInt(in, "radius", 0, &error);
-    if (error) {
-        radius = 0;
-    }
     if (radius == 0) {
         // spatial BM3D should handle everything itself
         auto node = vsapi->propGetNode(map, "clip", 0, nullptr);

--- a/source/source.cpp
+++ b/source/source.cpp
@@ -24,7 +24,9 @@
 #include <cmath>
 #include <concepts>
 #include <cstdint>
+#include <deque>
 #include <limits>
+#include <list>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
@@ -53,16 +55,6 @@ extern cudaGraphExec_t get_graphexec(
     bool final_, float extractor
 ) noexcept;
 
-extern std::variant<cudaGraphExec_t, std::string> get_fused_graphexec(
-    float * d_res, float * d_src, float * h_res,
-    int * d_params, int * h_params,
-    int width, int height, int stride,
-    float sigma, int block_step, int bm_range,
-    int radius, int ps_num, int ps_range,
-    bool chroma, float sigma_u, float sigma_v,
-    bool final_, float extractor
-) noexcept;
-
 extern std::variant<cudaGraphExec_t, std::string> get_rolling_graphexec(
     float * d_accum, float * d_scratch, float * d_src,
     float * h_src, float * h_output,
@@ -73,7 +65,7 @@ extern std::variant<cudaGraphExec_t, std::string> get_rolling_graphexec(
     int radius, int chunk_size, int process_mask, int video_planes,
     int subsampling_w, int subsampling_h,
     bool chroma, bool final_, float extractor
-) noexcept;
+);
 
 #define checkError(expr) do {                                            \
     if (cudaError_t result = expr; result != cudaSuccess) [[unlikely]] { \
@@ -181,11 +173,9 @@ struct BM3DData {
     bool chroma;
     bool process[3]; // sigma != 0
     bool final_;
-    bool fused;
     bool zero_init;
 
     int d_pitch;
-    size_t params_offset;
     int device_id;
 
     ticket_semaphore semaphore;
@@ -217,7 +207,7 @@ static void VS_CC BM3DInit(
 
     BM3DData * d = static_cast<BM3DData *>(*instanceData);
 
-    if (d->radius && !d->fused) {
+    if (d->radius) {
         VSVideoInfo vi = *d->vi;
         vi.height *= 2 * (2 * d->radius + 1);
         vsapi->setVideoInfo(&vi, 1, node);
@@ -234,7 +224,7 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
     auto d = static_cast<BM3DData *>(*instanceData);
 
     if (activationReason == arInitial) {
-        int64_t request_radius = d->fused ? 2LL * d->radius : d->radius;
+        const int64_t request_radius = d->radius;
         int start_frame = static_cast<int>(
             std::max<int64_t>(static_cast<int64_t>(n) - request_radius, 0));
         int end_frame = static_cast<int>(std::min<int64_t>(
@@ -260,13 +250,7 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
         int radius = d->radius;
         int temporal_width = 2 * radius + 1;
         bool final_ = d->final_;
-        bool fused = d->fused;
-        int64_t request_radius = fused ? 2LL * radius : radius;
-        int start_frame = static_cast<int>(
-            std::max<int64_t>(static_cast<int64_t>(n) - request_radius, 0));
-        int end_frame = static_cast<int>(std::min<int64_t>(
-            static_cast<int64_t>(n) + request_radius, d->vi->numFrames - 1));
-        int input_width = fused ? end_frame - start_frame + 1 : temporal_width;
+        int input_width = temporal_width;
         int num_input_frames = input_width * (final_ ? 2 : 1); // including ref
 
         using freeFrame_t = decltype(vsapi->freeFrame);
@@ -277,8 +261,7 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
 
             if (final_) {
                 for (int i = 0; i < input_width; ++i) {
-                    int clamped_n = fused ? start_frame + i :
-                        std::clamp(n - radius + i, 0, d->vi->numFrames - 1);
+                    int clamped_n = std::clamp(n - radius + i, 0, d->vi->numFrames - 1);
                     temp.emplace_back(
                         vsapi->getFrameFilter(clamped_n, d->ref_node, frameCtx),
                         vsapi->freeFrame
@@ -287,8 +270,7 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
             }
 
             for (int i = 0; i < input_width; ++i) {
-                int clamped_n = fused ? start_frame + i :
-                    std::clamp(n - radius + i, 0, d->vi->numFrames - 1);
+                int clamped_n = std::clamp(n - radius + i, 0, d->vi->numFrames - 1);
                 temp.emplace_back(
                     vsapi->getFrameFilter(clamped_n, d->node, frameCtx),
                     vsapi->freeFrame
@@ -298,11 +280,11 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
             return temp;
         }();
 
-        int center_index = fused ? n - start_frame : radius;
+        int center_index = radius;
         const VSFrameRef * src = srcs[center_index + (final_ ? input_width : 0)].get();
 
         std::unique_ptr<VSFrameRef, const freeFrame_t &> dst { nullptr, vsapi->freeFrame };
-        if (radius && !fused) {
+        if (radius) {
             dst.reset(
                 vsapi->newVideoFrame(
                     d->vi->format, d->vi->width,
@@ -378,22 +360,6 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
                         }
                         h_src += d_stride * height;
                     }
-                    if (fused) {
-                        h_src += d_stride * height * (4 * radius + 1 - input_width);
-                    }
-                }
-            }
-
-            if (fused) {
-                int * params = reinterpret_cast<int *>(
-                    reinterpret_cast<char *>(h_res) + d->params_offset);
-                params[0] = input_width;
-                for (int center = 0; center < temporal_width; ++center) {
-                    int center_frame = static_cast<int>(std::clamp<int64_t>(
-                        static_cast<int64_t>(n) - radius + center,
-                        0, d->vi->numFrames - 1));
-                    params[1 + 2 * center] = center_frame - start_frame;
-                    params[2 + 2 * center] = n - center_frame + radius;
                 }
             }
 
@@ -404,25 +370,23 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
             float * h_dst = h_res;
             for (int plane = 0; plane < std::ssize(d->process); ++plane) {
                 if (!d->process[plane]) {
-                    h_dst += d_stride * height * 2 * (fused ? 1 : temporal_width);
+                    h_dst += d_stride * height * 2 * temporal_width;
                     continue;
                 }
 
                 float * dstp = reinterpret_cast<float *>(
                     vsapi->getWritePtr(dst.get(), plane));
 
-                if (radius && !fused) {
+                if (radius) {
                     vs_bitblt(
                         dstp, s_pitch, h_dst, d_pitch,
                         width_bytes, height * 2 * temporal_width
                     );
-                } else if (fused) {
-                    vs_bitblt(dstp, s_pitch, h_dst, d_pitch, width_bytes, height);
                 } else {
                     Aggregation(dstp, s_stride, h_dst, d_stride, width, height);
                 }
 
-                h_dst += d_stride * height * 2 * (fused ? 1 : temporal_width);
+                h_dst += d_stride * height * 2 * temporal_width;
             }
         } else { // !d->chroma
             for (int plane = 0; plane < d->vi->format->numPlanes; plane++) {
@@ -446,22 +410,6 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
                         width_bytes, height
                     );
                     h_src += d_stride * height;
-                    if (fused && (i + 1) % input_width == 0) {
-                        h_src += d_stride * height * (4 * radius + 1 - input_width);
-                    }
-                }
-
-                if (fused) {
-                    int * params = reinterpret_cast<int *>(
-                        reinterpret_cast<char *>(h_res) + d->params_offset);
-                    params[0] = input_width;
-                    for (int center = 0; center < temporal_width; ++center) {
-                        int center_frame = static_cast<int>(std::clamp<int64_t>(
-                            static_cast<int64_t>(n) - radius + center,
-                            0, d->vi->numFrames - 1));
-                        params[1 + 2 * center] = center_frame - start_frame;
-                        params[2 + 2 * center] = n - center_frame + radius;
-                    }
                 }
 
                 checkError(cudaGraphLaunch(graphexec, stream));
@@ -471,13 +419,11 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
                 float * dstp = reinterpret_cast<float *>(
                     vsapi->getWritePtr(dst.get(), plane));
 
-                if (radius && !fused) {
+                if (radius) {
                     vs_bitblt(
                         dstp, s_pitch, h_res, d_pitch,
                         width_bytes, height * 2 * temporal_width
                     );
-                } else if (fused) {
-                    vs_bitblt(dstp, s_pitch, h_res, d_pitch, width_bytes, height);
                 } else {
                     Aggregation(dstp, s_stride, h_res, d_stride, width, height);
                 }
@@ -489,7 +435,7 @@ static const VSFrameRef *VS_CC BM3DGetFrame(
         d->resources_lock.unlock();
         d->semaphore.release();
 
-        if (radius && !fused) {
+        if (radius) {
             VSMap * dst_prop { vsapi->getFramePropsRW(dst.get()) };
 
             vsapi->propSetInt(dst_prop, "BM3D_V_radius", d->radius, paReplace);
@@ -520,7 +466,7 @@ static void VS_CC BM3DFree(
 
 static void BM3DCreateImpl(
     const VSMap *in, VSMap *out, void *userData,
-    VSCore *core, const VSAPI *vsapi, bool fused
+    VSCore *core, const VSAPI *vsapi
 ) noexcept {
 
     auto d { std::make_unique<BM3DData>() };
@@ -563,7 +509,6 @@ static void BM3DCreateImpl(
         final_ = true;
     }
     d->final_ = final_;
-    d->fused = fused;
 
     float sigma[3];
     for (int i = 0; i < std::ssize(sigma); ++i) {
@@ -620,9 +565,6 @@ static void BM3DCreateImpl(
     }();
     if (radius < 0) {
         return set_error("\"radius\" must be non-negative");
-    }
-    if (fused && radius > (std::numeric_limits<int>::max() - 1) / 4) {
-        return set_error("\"radius\" is too large for fused temporal processing");
     }
     d->radius = radius;
 
@@ -712,30 +654,12 @@ static void BM3DCreateImpl(
 
         const int num_planes { chroma ? 3 : 1 };
         const int temporal_width = 2 * radius + 1;
-        const int source_temporal_width = fused ? 4 * radius + 1 : temporal_width;
-        if (fused) {
-            const size_t min_temporal_stride =
-                static_cast<size_t>(max_width) * max_height;
-            const size_t max_kernel_offset = std::numeric_limits<int>::max();
-            if (
-                min_temporal_stride > max_kernel_offset ||
-                static_cast<size_t>(source_temporal_width) >
-                    max_kernel_offset / min_temporal_stride ||
-                static_cast<size_t>(num_planes) > max_kernel_offset /
-                    (min_temporal_stride * source_temporal_width)) {
-                return set_error("\"radius\" is too large for the clip dimensions");
-            }
-        }
+        const int source_temporal_width = temporal_width;
         const size_t source_rows = static_cast<size_t>(final_ ? 2 : 1) *
             static_cast<size_t>(num_planes) * source_temporal_width * max_height;
         const size_t result_rows = static_cast<size_t>(num_planes) *
             temporal_width * 2 * max_height;
         const size_t buffer_rows = std::max(source_rows, result_rows);
-        const size_t params_size = fused ?
-            (1 + 2 * static_cast<size_t>(temporal_width)) * sizeof(int) : 0;
-        const size_t min_pitch = static_cast<size_t>(max_width) * sizeof(float);
-        const size_t params_rows = fused ?
-            (params_size + min_pitch - 1) / min_pitch : 0;
         size_t d_pitch;
         int d_stride;
         for (int i = 0; i < num_copy_engines; ++i) {
@@ -743,30 +667,15 @@ static void BM3DCreateImpl(
             if (i == 0) {
                 checkError(cudaMallocPitch(
                     &d_src.data, &d_pitch, max_width * sizeof(float),
-                    fused ? buffer_rows + params_rows : source_rows));
+                    source_rows));
                 if (d_pitch >
                     static_cast<size_t>(std::numeric_limits<int>::max())) {
                     return set_error("device pitch exceeds the supported range");
                 }
                 d_stride = static_cast<int>(d_pitch / sizeof(float));
-                if (fused) {
-                    const size_t temporal_stride =
-                        static_cast<size_t>(max_height) * d_stride;
-                    const size_t max_kernel_offset = std::numeric_limits<int>::max();
-                    if (
-                        temporal_stride > max_kernel_offset ||
-                        static_cast<size_t>(source_temporal_width) >
-                            max_kernel_offset / temporal_stride ||
-                        static_cast<size_t>(num_planes) > max_kernel_offset /
-                            (temporal_stride * source_temporal_width)) {
-                        return set_error("\"radius\" is too large for the device pitch");
-                    }
-                }
                 d->d_pitch = static_cast<int>(d_pitch);
-                d->params_offset = buffer_rows * d_pitch;
             } else {
-                checkError(cudaMalloc(&d_src.data,
-                    fused ? buffer_rows * d_pitch + params_size : source_rows * d_pitch));
+                checkError(cudaMalloc(&d_src.data, source_rows * d_pitch));
             }
 
             Resource<float *, cudaFree> d_res {};
@@ -774,7 +683,7 @@ static void BM3DCreateImpl(
 
             Resource<float *, cudaFreeHost> h_res {};
             checkError(cudaMallocHost(&h_res.data,
-                buffer_rows * d_pitch + params_size));
+                buffer_rows * d_pitch));
 
             Resource<cudaStream_t, cudaStreamDestroy> stream {};
             checkError(cudaStreamCreateWithFlags(&stream.data,
@@ -782,28 +691,12 @@ static void BM3DCreateImpl(
 
             std::array<Resource<cudaGraphExec_t, cudaGraphExecDestroy>, 3> graphexecs {};
             if (d->chroma) {
-                if (fused) {
-                    const auto result = get_fused_graphexec(
-                        d_res, d_src, h_res,
-                        reinterpret_cast<int *>(reinterpret_cast<char *>(d_src.data) + d->params_offset),
-                        reinterpret_cast<int *>(reinterpret_cast<char *>(h_res.data) + d->params_offset),
-                        width, height, d_stride,
-                        sigma[0], block_step[0], bm_range[0],
-                        radius, ps_num[0], ps_range[0],
-                        true, sigma[1], sigma[2], final_, extractor);
-                    if (std::holds_alternative<cudaGraphExec_t>(result)) {
-                        graphexecs[0] = std::get<cudaGraphExec_t>(result);
-                    } else {
-                        return set_error(std::get<std::string>(result));
-                    }
-                } else {
-                    graphexecs[0] = get_graphexec(
-                        d_res, d_src, h_res,
-                        width, height, d_stride,
-                        sigma[0], block_step[0], bm_range[0],
-                        radius, ps_num[0], ps_range[0],
-                        true, sigma[1], sigma[2], final_, extractor);
-                }
+                graphexecs[0] = get_graphexec(
+                    d_res, d_src, h_res,
+                    width, height, d_stride,
+                    sigma[0], block_step[0], bm_range[0],
+                    radius, ps_num[0], ps_range[0],
+                    true, sigma[1], sigma[2], final_, extractor);
             } else {
                 auto subsamplingW = d->vi->format->subSamplingW;
                 auto subsamplingH = d->vi->format->subSamplingH;
@@ -813,28 +706,12 @@ static void BM3DCreateImpl(
                         int plane_width { plane == 0 ? width : width >> subsamplingW };
                         int plane_height { plane == 0 ? height : height >> subsamplingH };
 
-                        if (fused) {
-                            const auto result = get_fused_graphexec(
-                                d_res, d_src, h_res,
-                                reinterpret_cast<int *>(reinterpret_cast<char *>(d_src.data) + d->params_offset),
-                                reinterpret_cast<int *>(reinterpret_cast<char *>(h_res.data) + d->params_offset),
-                                plane_width, plane_height, d_stride,
-                                sigma[plane], block_step[plane], bm_range[plane],
-                                radius, ps_num[plane], ps_range[plane],
-                                false, 0.0f, 0.0f, final_, extractor);
-                            if (std::holds_alternative<cudaGraphExec_t>(result)) {
-                                graphexecs[plane] = std::get<cudaGraphExec_t>(result);
-                            } else {
-                                return set_error(std::get<std::string>(result));
-                            }
-                        } else {
-                            graphexecs[plane] = get_graphexec(
-                                d_res, d_src, h_res,
-                                plane_width, plane_height, d_stride,
-                                sigma[plane], block_step[plane], bm_range[plane],
-                                radius, ps_num[plane], ps_range[plane],
-                                false, 0.0f, 0.0f, final_, extractor);
-                        }
+                        graphexecs[plane] = get_graphexec(
+                            d_res, d_src, h_res,
+                            plane_width, plane_height, d_stride,
+                            sigma[plane], block_step[plane], bm_range[plane],
+                            radius, ps_num[plane], ps_range[plane],
+                            false, 0.0f, 0.0f, final_, extractor);
                     }
                 }
             }
@@ -850,7 +727,7 @@ static void BM3DCreateImpl(
     }
 
     vsapi->createFilter(
-        in, out, fused ? "BM3Dv2" : "BM3D",
+        in, out, "BM3D",
         BM3DInit, BM3DGetFrame, BM3DFree,
         fmParallel, 0, d.release(), core
     );
@@ -860,7 +737,7 @@ static void VS_CC BM3DCreate(
     const VSMap *in, VSMap *out, void *userData,
     VSCore *core, const VSAPI *vsapi
 ) noexcept {
-    BM3DCreateImpl(in, out, userData, core, vsapi, false);
+    BM3DCreateImpl(in, out, userData, core, vsapi);
 }
 
 struct RollingResource {
@@ -879,9 +756,13 @@ struct RollingData {
     VSNodeRef * node {};
     VSNodeRef * ref_node {};
     const VSVideoInfo * vi {};
+    const VSAPI * vsapi {};
 
     int radius {};
     int chunk_size {};
+    std::atomic<int> cache_chunks { 1 };
+    int cache_limit { 1 };
+    bool cache_adaptive {};
     int device_id {};
     int d_pitch {};
     bool chroma {};
@@ -893,14 +774,60 @@ struct RollingData {
     size_t output_plane_rows[3] {};
     size_t output_step_rows[3] {};
     RollingResource resource;
+    std::mutex resource_lock;
 
     mutable std::shared_mutex cache_lock;
-    int cached_start { -1 };
-    std::vector<const VSFrameRef *> cached_frames;
-};
+    struct CacheChunk {
+        int start {};
+        std::vector<const VSFrameRef *> frames;
 
-struct RollingRequest {
-    int chunk_start;
+        const VSAPI * vsapi {};
+
+        CacheChunk() noexcept = default;
+
+        CacheChunk(
+            int start_, std::vector<const VSFrameRef *> && frames_,
+            const VSAPI * vsapi_
+        ) noexcept :
+            start { start_ }, frames { std::move(frames_) }, vsapi { vsapi_ }
+        {}
+
+        CacheChunk(const CacheChunk &) = delete;
+        CacheChunk & operator=(const CacheChunk &) = delete;
+
+        CacheChunk(CacheChunk && other) noexcept :
+            start { other.start }, frames { std::move(other.frames) },
+            vsapi { std::exchange(other.vsapi, nullptr) }
+        {}
+
+        CacheChunk & operator=(CacheChunk && other) noexcept {
+            if (this != &other) {
+                release();
+                start = other.start;
+                frames = std::move(other.frames);
+                vsapi = std::exchange(other.vsapi, nullptr);
+            }
+            return *this;
+        }
+
+        ~CacheChunk() noexcept { release(); }
+
+    private:
+        void release() noexcept {
+            if (!vsapi) return;
+            for (const VSFrameRef * frame : frames) {
+                vsapi->freeFrame(frame);
+            }
+        }
+    };
+    std::list<CacheChunk> cached_chunks;
+    std::deque<int> evicted_chunks;
+    int cache_reuse_events {};
+
+    ~RollingData() noexcept {
+        if (node) vsapi->freeNode(node);
+        if (ref_node) vsapi->freeNode(ref_node);
+    }
 };
 
 static bool checked_mul(size_t lhs, size_t rhs, size_t & result) noexcept {
@@ -928,38 +855,70 @@ static void VS_CC RollingInit(
 }
 
 static const VSFrameRef * rolling_cache_get(
-    const RollingData * d, int n, const VSAPI * vsapi
-) noexcept {
-    std::shared_lock lock { d->cache_lock };
-    const int offset = n - d->cached_start;
-    if (offset < 0 || offset >= std::ssize(d->cached_frames)) {
-        return nullptr;
+    RollingData * d, int n, const VSAPI * vsapi
+) {
+    if (d->cache_chunks.load(std::memory_order_relaxed) == 1) {
+        std::shared_lock lock { d->cache_lock };
+        if (d->cached_chunks.empty()) return nullptr;
+        const auto & cache = d->cached_chunks.front();
+        const int offset = n - cache.start;
+        if (offset < 0 || offset >= std::ssize(cache.frames)) {
+            return nullptr;
+        }
+        return vsapi->cloneFrameRef(cache.frames[offset]);
     }
-    return vsapi->cloneFrameRef(d->cached_frames[offset]);
+
+    std::unique_lock lock { d->cache_lock };
+    for (auto it = d->cached_chunks.begin(); it != d->cached_chunks.end();
+        ++it) {
+        const int offset = n - it->start;
+        if (offset < 0 || offset >= std::ssize(it->frames)) continue;
+        if (std::next(it) != d->cached_chunks.end()) {
+            d->cached_chunks.splice(
+                d->cached_chunks.end(), d->cached_chunks, it);
+            it = std::prev(d->cached_chunks.end());
+        }
+        return vsapi->cloneFrameRef(it->frames[offset]);
+    }
+    return nullptr;
 }
 
-static const VSFrameRef *VS_CC RollingGetFrame(
-    int n, int activationReason, void **instanceData, void **frameData,
+static void rolling_cache_maybe_grow(
+    RollingData * d, int chunk_start
+) {
+    if (!d->cache_adaptive) return;
+
+    std::unique_lock lock { d->cache_lock };
+    if (d->cache_chunks.load(std::memory_order_relaxed) >= d->cache_limit) {
+        return;
+    }
+    const auto evicted = std::find(
+        d->evicted_chunks.begin(), d->evicted_chunks.end(), chunk_start);
+    if (evicted == d->evicted_chunks.end()) return;
+    d->evicted_chunks.erase(evicted);
+    if (++d->cache_reuse_events < 2) return;
+    d->cache_reuse_events = 0;
+    d->cache_chunks.fetch_add(1, std::memory_order_relaxed);
+}
+
+static const VSFrameRef * RollingGetFrameImpl(
+    int n, int activationReason, void **instanceData, void **,
     VSFrameContext *frameCtx, VSCore *core, const VSAPI *vsapi
-) noexcept {
+) {
     auto d = static_cast<RollingData *>(*instanceData);
 
     if (activationReason == arInitial) {
-        const int chunk_start = n / d->chunk_size * d->chunk_size;
-        *frameData = new RollingRequest { chunk_start };
-
         if (const VSFrameRef * cached = rolling_cache_get(d, n, vsapi)) {
-            delete static_cast<RollingRequest *>(*frameData);
-            *frameData = nullptr;
             return cached;
         }
 
+        const int64_t chunk_start =
+            static_cast<int64_t>(n / d->chunk_size) * d->chunk_size;
+        const int64_t clip_last = static_cast<int64_t>(d->vi->numFrames) - 1;
         const int64_t first = std::max<int64_t>(
-            static_cast<int64_t>(chunk_start) - 2LL * d->radius, 0);
+            chunk_start - 2LL * d->radius, 0);
         const int64_t last = std::min<int64_t>(
-            static_cast<int64_t>(chunk_start) + d->chunk_size - 1 +
-                2LL * d->radius,
-            d->vi->numFrames - 1);
+            chunk_start + d->chunk_size - 1 + 2LL * d->radius, clip_last);
         for (int64_t frame = first; frame <= last; ++frame) {
             vsapi->requestFrameFilter(static_cast<int>(frame), d->node, frameCtx);
         }
@@ -973,8 +932,6 @@ static const VSFrameRef *VS_CC RollingGetFrame(
     }
 
     if (activationReason == arError) {
-        delete static_cast<RollingRequest *>(*frameData);
-        *frameData = nullptr;
         return nullptr;
     }
 
@@ -982,14 +939,19 @@ static const VSFrameRef *VS_CC RollingGetFrame(
         return nullptr;
     }
 
-    std::unique_ptr<RollingRequest> request {
-        static_cast<RollingRequest *>(*frameData)
-    };
-    *frameData = nullptr;
-
     if (const VSFrameRef * cached = rolling_cache_get(d, n, vsapi)) {
         return cached;
     }
+
+    std::unique_lock resource_guard { d->resource_lock };
+    if (const VSFrameRef * cached = rolling_cache_get(d, n, vsapi)) {
+        return cached;
+    }
+
+    const int64_t chunk_start_64 =
+        static_cast<int64_t>(n / d->chunk_size) * d->chunk_size;
+    const int chunk_start = static_cast<int>(chunk_start_64);
+    rolling_cache_maybe_grow(d, chunk_start);
 
     const auto set_error = [&](const std::string & error_message) {
         vsapi->setFilterError(
@@ -1001,16 +963,17 @@ static const VSFrameRef *VS_CC RollingGetFrame(
         return set_error(cudaGetErrorString(result));
     }
 
-    const int chunk_start = request->chunk_start;
-    const int valid_outputs = std::min(
-        d->chunk_size, d->vi->numFrames - chunk_start);
-    const int logical_first = chunk_start - 2 * d->radius;
+    const int64_t clip_last = static_cast<int64_t>(d->vi->numFrames) - 1;
+    const int valid_outputs = static_cast<int>(std::min<int64_t>(
+        d->chunk_size, static_cast<int64_t>(d->vi->numFrames) - chunk_start_64));
+    const int64_t logical_first = chunk_start_64 - 2LL * d->radius;
     const int logical_source_width = d->chunk_size + 4 * d->radius;
     const int centers = d->chunk_size + 2 * d->radius;
-    const int first_frame = std::max(logical_first, 0);
-    const int last_frame = std::min(
-        chunk_start + d->chunk_size - 1 + 2 * d->radius,
-        d->vi->numFrames - 1);
+    const int first_frame = static_cast<int>(std::max<int64_t>(
+        logical_first, 0));
+    const int last_frame = static_cast<int>(std::min<int64_t>(
+        chunk_start_64 + d->chunk_size - 1 + 2LL * d->radius,
+        clip_last));
     const int unique_frames = last_frame - first_frame + 1;
 
     using freeFrame_t = decltype(vsapi->freeFrame);
@@ -1019,14 +982,17 @@ static const VSFrameRef *VS_CC RollingGetFrame(
     std::vector<FramePtr> reference_frames;
     source_frames.reserve(unique_frames);
     reference_frames.reserve(d->final_ ? unique_frames : 0);
-    for (int frame = first_frame; frame <= last_frame; ++frame) {
+    for (int64_t frame = first_frame; frame <= last_frame; ++frame) {
         source_frames.emplace_back(
-            vsapi->getFrameFilter(frame, d->node, frameCtx), vsapi->freeFrame);
+            vsapi->getFrameFilter(
+                static_cast<int>(frame), d->node, frameCtx),
+            vsapi->freeFrame);
     }
     if (d->final_) {
-        for (int frame = first_frame; frame <= last_frame; ++frame) {
+        for (int64_t frame = first_frame; frame <= last_frame; ++frame) {
             reference_frames.emplace_back(
-                vsapi->getFrameFilter(frame, d->ref_node, frameCtx),
+                vsapi->getFrameFilter(
+                    static_cast<int>(frame), d->ref_node, frameCtx),
                 vsapi->freeFrame);
         }
     }
@@ -1040,8 +1006,8 @@ static const VSFrameRef *VS_CC RollingGetFrame(
         const int width = vsapi->getFrameWidth(frames.front().get(), plane);
         const int source_pitch = vsapi->getStride(frames.front().get(), plane);
         for (int logical = 0; logical < logical_source_width; ++logical) {
-            const int frame = std::clamp(
-                logical_first + logical, 0, d->vi->numFrames - 1);
+            const int frame = static_cast<int>(std::clamp<int64_t>(
+                logical_first + logical, 0, clip_last));
             const VSFrameRef * source = frames[frame - first_frame].get();
             vs_bitblt(
                 h_dst, d->d_pitch, vsapi->getReadPtr(source, plane),
@@ -1077,10 +1043,10 @@ static const VSFrameRef *VS_CC RollingGetFrame(
 
         resource.h_params.data[0] = logical_source_width;
         for (int center = 0; center < centers; ++center) {
-            const int frame = std::clamp(
-                chunk_start - d->radius + center,
-                0, d->vi->numFrames - 1);
-            resource.h_params.data[1 + center] = frame - logical_first;
+            const int64_t frame = std::clamp<int64_t>(
+                chunk_start_64 - d->radius + center, 0, clip_last);
+            resource.h_params.data[1 + center] =
+                static_cast<int>(frame - logical_first);
         }
 
         if (cudaError_t result = cudaGraphLaunch(
@@ -1096,8 +1062,9 @@ static const VSFrameRef *VS_CC RollingGetFrame(
     std::vector<const VSFrameRef *> new_cache;
     new_cache.reserve(valid_outputs);
     for (int output = 0; output < valid_outputs; ++output) {
-        const VSFrameRef * source =
-            source_frames[chunk_start + output - first_frame].get();
+        const size_t source_index = static_cast<size_t>(
+            chunk_start_64 + output - first_frame);
+        const VSFrameRef * source = source_frames[source_index].get();
         const VSFrameRef * plane_sources[] {
             d->process[0] ? nullptr : source,
             d->process[1] ? nullptr : source,
@@ -1126,49 +1093,78 @@ static const VSFrameRef *VS_CC RollingGetFrame(
         new_cache.push_back(destination);
     }
 
-    std::vector<const VSFrameRef *> old_cache;
+    RollingData::CacheChunk new_chunk {
+        chunk_start, std::move(new_cache), vsapi
+    };
+    std::list<RollingData::CacheChunk> evicted;
     {
         std::unique_lock lock { d->cache_lock };
-        old_cache = std::move(d->cached_frames);
-        d->cached_frames = std::move(new_cache);
-        d->cached_start = chunk_start;
-    }
-    for (const VSFrameRef * frame : old_cache) {
-        vsapi->freeFrame(frame);
+        d->cached_chunks.push_back(std::move(new_chunk));
+        while (std::ssize(d->cached_chunks) >
+            d->cache_chunks.load(std::memory_order_relaxed)) {
+            evicted.splice(evicted.end(), d->cached_chunks,
+                d->cached_chunks.begin());
+            if (d->cache_adaptive) {
+                d->evicted_chunks.push_back(evicted.back().start);
+                const size_t history_limit = std::max(
+                    size_t { 8 }, static_cast<size_t>(d->cache_limit) * 2);
+                while (d->evicted_chunks.size() > history_limit) {
+                    d->evicted_chunks.pop_front();
+                }
+            }
+        }
     }
     return rolling_cache_get(d, n, vsapi);
+}
+
+static const VSFrameRef *VS_CC RollingGetFrame(
+    int n, int activationReason, void **instanceData, void **frameData,
+    VSFrameContext *frameCtx, VSCore *core, const VSAPI *vsapi
+) noexcept {
+    try {
+        return RollingGetFrameImpl(
+            n, activationReason, instanceData, frameData,
+            frameCtx, core, vsapi);
+    } catch (const std::bad_alloc &) {
+        vsapi->setFilterError(
+            "BM3Dv2 rolling: memory allocation failed", frameCtx);
+    } catch (const std::exception & error) {
+        vsapi->setFilterError(error.what(), frameCtx);
+    } catch (...) {
+        vsapi->setFilterError("BM3Dv2 rolling: internal error", frameCtx);
+    }
+    return nullptr;
 }
 
 static void VS_CC RollingFree(
     void *instanceData, VSCore *core, const VSAPI *vsapi
 ) noexcept {
     auto d = static_cast<RollingData *>(instanceData);
-    std::vector<const VSFrameRef *> cached_frames;
+    std::list<RollingData::CacheChunk> cached_chunks;
     {
         std::unique_lock lock { d->cache_lock };
-        cached_frames = std::move(d->cached_frames);
-        d->cached_start = -1;
+        cached_chunks.splice(
+            cached_chunks.end(), d->cached_chunks);
     }
-    for (const VSFrameRef * frame : cached_frames) {
-        vsapi->freeFrame(frame);
-    }
-    vsapi->freeNode(d->node);
-    vsapi->freeNode(d->ref_node);
+    cached_chunks.clear();
     cudaSetDevice(d->device_id);
     delete d;
 }
 
 static void RollingCreate(
-    const VSMap *in, VSMap *out, int chunk_size,
+    const VSMap *in, VSMap *out, int chunk_size, int cache_chunks,
+    int cache_limit, bool cache_adaptive,
     VSCore *core, const VSAPI *vsapi
 ) noexcept {
     try {
     auto d = std::make_unique<RollingData>();
+    d->vsapi = vsapi;
+    d->cache_chunks.store(cache_chunks, std::memory_order_relaxed);
+    d->cache_limit = cache_limit;
+    d->cache_adaptive = cache_adaptive;
 
     const auto set_error = [&](const std::string & error_message) {
         vsapi->setError(out, ("BM3Dv2 rolling: " + error_message).c_str());
-        vsapi->freeNode(d->node);
-        vsapi->freeNode(d->ref_node);
     };
 
     d->node = vsapi->propGetNode(in, "clip", 0, nullptr);
@@ -1463,6 +1459,10 @@ static void RollingCreate(
         fmParallelRequests, 0, d.release(), core);
     } catch (const std::bad_alloc &) {
         vsapi->setError(out, "BM3Dv2 rolling: memory allocation failed");
+    } catch (const std::exception & error) {
+        vsapi->setError(out, error.what());
+    } catch (...) {
+        vsapi->setError(out, "BM3Dv2 rolling: internal error");
     }
 }
 
@@ -1688,7 +1688,9 @@ static VSMap * copy_bm3d_args(
         const char * key = vsapi->propGetKey(in, key_index);
         if (
             std::string_view { key } == "temporal_mode" ||
-            std::string_view { key } == "rolling_chunk") {
+            std::string_view { key } == "rolling_chunk" ||
+            std::string_view { key } == "rolling_cache_chunks" ||
+            std::string_view { key } == "rolling_cache_limit") {
             continue;
         }
         const int elements = vsapi->propNumElements(in, key);
@@ -1710,6 +1712,13 @@ static VSMap * copy_bm3d_args(
                 vsapi->freeNode(node);
                 break;
             }
+            case ptData: {
+                const char * data = vsapi->propGetData(in, key, index, nullptr);
+                vsapi->propSetData(
+                    result, key, data,
+                    vsapi->propGetDataSize(in, key, index, nullptr), paAppend);
+                break;
+            }
             default:
                 break;
             }
@@ -1723,8 +1732,10 @@ static void VS_CC BM3Dv2Create(
     VSCore *core, const VSAPI *vsapi
 ) {
     int error;
-    std::string temporal_mode { "fused" };
-    if (vsapi->propNumElements(in, "temporal_mode") >= 0) {
+    std::string temporal_mode { "rolling" };
+    const bool temporal_mode_supplied =
+        vsapi->propNumElements(in, "temporal_mode") >= 0;
+    if (temporal_mode_supplied) {
         const char * value = vsapi->propGetData(
             in, "temporal_mode", 0, &error);
         const int size = vsapi->propGetDataSize(
@@ -1736,11 +1747,10 @@ static void VS_CC BM3Dv2Create(
         temporal_mode.assign(value, size);
     }
     if (
-        temporal_mode != "fused" && temporal_mode != "legacy" &&
-        temporal_mode != "rolling") {
+        temporal_mode != "legacy" && temporal_mode != "rolling") {
         vsapi->setError(
             out,
-            "BM3Dv2: \"temporal_mode\" must be one of fused, legacy, or rolling");
+            "BM3Dv2: \"temporal_mode\" must be one of legacy or rolling");
         return;
     }
 
@@ -1752,7 +1762,7 @@ static void VS_CC BM3Dv2Create(
             "BM3Dv2: \"rolling_chunk\" is valid only when temporal_mode is rolling");
         return;
     }
-    int rolling_chunk = 16;
+    int rolling_chunk = 4;
     if (chunk_supplied) {
         rolling_chunk = int64ToIntS(
             vsapi->propGetInt(in, "rolling_chunk", 0, &error));
@@ -1763,11 +1773,56 @@ static void VS_CC BM3Dv2Create(
         }
     }
 
+    const bool cache_chunks_supplied =
+        vsapi->propNumElements(in, "rolling_cache_chunks") >= 0;
+    if (cache_chunks_supplied && temporal_mode != "rolling") {
+        vsapi->setError(out,
+            "BM3Dv2: \"rolling_cache_chunks\" is valid only when temporal_mode is rolling");
+        return;
+    }
+    int rolling_cache_chunks = 1;
+    if (cache_chunks_supplied) {
+        rolling_cache_chunks = int64ToIntS(
+            vsapi->propGetInt(in, "rolling_cache_chunks", 0, &error));
+        if (error || rolling_cache_chunks < 1 || rolling_cache_chunks > 64) {
+            vsapi->setError(out,
+                "BM3Dv2: \"rolling_cache_chunks\" must be in range [1, 64]");
+            return;
+        }
+    }
+
+    const bool cache_limit_supplied =
+        vsapi->propNumElements(in, "rolling_cache_limit") >= 0;
+    if (cache_limit_supplied && temporal_mode != "rolling") {
+        vsapi->setError(out,
+            "BM3Dv2: \"rolling_cache_limit\" is valid only when temporal_mode is rolling");
+        return;
+    }
+    int rolling_cache_limit = 16;
+    if (cache_limit_supplied) {
+        rolling_cache_limit = int64ToIntS(
+            vsapi->propGetInt(in, "rolling_cache_limit", 0, &error));
+        if (error || rolling_cache_limit < 1 || rolling_cache_limit > 64) {
+            vsapi->setError(out,
+                "BM3Dv2: \"rolling_cache_limit\" must be in range [1, 64]");
+            return;
+        }
+    }
+    if (rolling_cache_limit < rolling_cache_chunks) {
+        vsapi->setError(out,
+            "BM3Dv2: \"rolling_cache_limit\" must be greater than or equal to \"rolling_cache_chunks\"");
+        return;
+    }
+    const bool cache_adaptive = cache_limit_supplied || !cache_chunks_supplied;
+    if (!cache_adaptive) {
+        rolling_cache_limit = rolling_cache_chunks;
+    }
+
     int radius = int64ToIntS(vsapi->propGetInt(in, "radius", 0, &error));
     if (error) {
         radius = 0;
     }
-    if (temporal_mode == "rolling" && radius <= 0) {
+    if (temporal_mode_supplied && temporal_mode == "rolling" && radius <= 0) {
         vsapi->setError(
             out, "BM3Dv2: rolling temporal mode requires radius greater than zero");
         return;
@@ -1796,7 +1851,7 @@ static void VS_CC BM3Dv2Create(
     for (int i = 0; i < source_planes; ++i) {
         skip &= !process[i];
     }
-    if (skip && temporal_mode != "rolling") {
+    if (skip) {
         vsapi->propSetNode(out, "clip", src, paReplace);
         vsapi->freeNode(src);
         return ;
@@ -1804,10 +1859,10 @@ static void VS_CC BM3Dv2Create(
 
     if (radius > 0) {
         vsapi->freeNode(src);
-        if (temporal_mode == "fused") {
-            BM3DCreateImpl(in, out, userData, core, vsapi, true);
-        } else if (temporal_mode == "rolling") {
-            RollingCreate(in, out, rolling_chunk, core, vsapi);
+        if (temporal_mode == "rolling") {
+            RollingCreate(
+                in, out, rolling_chunk, rolling_cache_chunks,
+                rolling_cache_limit, cache_adaptive, core, vsapi);
         } else {
             auto plugin = vsapi->getPluginById(PLUGIN_ID, core);
             VSMap * bm3d_in = copy_bm3d_args(in, vsapi);
@@ -1938,7 +1993,9 @@ VS_EXTERNAL_API(void) VapourSynthPluginInit(
         "extractor_exp:int:opt;"
         "zero_init:int:opt;"
         "temporal_mode:data:opt;"
-        "rolling_chunk:int:opt;"
+            "rolling_chunk:int:opt;"
+            "rolling_cache_chunks:int:opt;"
+            "rolling_cache_limit:int:opt;"
     };
     registerFunc("BM3Dv2", bm3dv2_args, BM3Dv2Create, nullptr, plugin);
 }

--- a/sycl_source/source.cpp
+++ b/sycl_source/source.cpp
@@ -875,17 +875,42 @@ static void VS_CC VAggregateCreate(
 
     auto d { std::make_unique<VAggregateData>() };
 
+    const auto set_error = [&](const std::string & error_message) {
+        vsapi->setError(out, ("VAggregate: " + error_message).c_str());
+        if (d->src_node) {
+            vsapi->freeNode(d->src_node);
+        }
+        if (d->node) {
+            vsapi->freeNode(d->node);
+        }
+    };
+
     d->node = vsapi->propGetNode(in, "clip", 0, nullptr);
     auto vi = vsapi->getVideoInfo(d->node);
     d->src_node = vsapi->propGetNode(in, "src", 0, nullptr);
     d->src_vi = vsapi->getVideoInfo(d->src_node);
+
+    const int num_planes = d->src_vi->format->numPlanes;
+    if (num_planes > static_cast<int>(d->process.size())) {
+        return set_error("source clip has too many planes");
+    }
 
     d->radius = (vi->height / d->src_vi->height - 2) / 4;
 
     d->process.fill(false);
     int num_planes_args = vsapi->propNumElements(in, "planes");
     for (int i = 0; i < num_planes_args; ++i) {
-        int plane = vsapi->propGetInt(in, "planes", i, nullptr);
+        int error;
+        int plane = int64ToIntS(vsapi->propGetInt(in, "planes", i, &error));
+        if (error) {
+            return set_error("\"planes\" must contain only integers");
+        }
+        if (plane < 0 || plane >= num_planes) {
+            return set_error("\"planes\" contains an out-of-range plane index");
+        }
+        if (d->process[plane]) {
+            return set_error("\"planes\" contains a duplicate plane index");
+        }
         d->process[plane] = true;
     }
 

--- a/tests/test_rtc_cuda_rolling.py
+++ b/tests/test_rtc_cuda_rolling.py
@@ -23,8 +23,8 @@ def patterned_clip(format_id: int, length: int = 11) -> vs.VideoNode:
         width=32, height=24, format=format_id, length=length
     )
 
-    def fill(n: int, frame: vs.VideoFrame) -> vs.VideoFrame:
-        output = frame.copy()
+    def fill(n: int, f: vs.VideoFrame) -> vs.VideoFrame:
+        output = f.copy()
         for plane in range(output.format.num_planes):
             array = np.asarray(output[plane])
             y, x = np.indices(array.shape)
@@ -54,10 +54,13 @@ def assert_frames_equal(left: vs.VideoNode, right: vs.VideoNode, order) -> None:
     "arguments",
     [
         {"temporal_mode": "invalid", "radius": 1},
-        {"temporal_mode": "fused", "radius": 1, "rolling_chunk": 4},
+        {"temporal_mode": "fused", "radius": 1},
         {"temporal_mode": "legacy", "radius": 1, "rolling_chunk": 4},
+        {"temporal_mode": "legacy", "radius": 1, "rolling_cache_chunks": 2},
         {"temporal_mode": "rolling", "radius": 1, "rolling_chunk": 0},
         {"temporal_mode": "rolling", "radius": 1, "rolling_chunk": 65},
+        {"temporal_mode": "rolling", "radius": 1, "rolling_cache_chunks": 0},
+        {"temporal_mode": "rolling", "radius": 1, "rolling_cache_chunks": 65},
         {"temporal_mode": "rolling", "radius": 0},
     ],
 )
@@ -67,12 +70,37 @@ def test_selector_rejects_invalid_combinations(arguments) -> None:
         bm3dcuda.BM3Dv2(source, **arguments)
 
 
-def test_default_is_explicit_fused() -> None:
+def test_default_is_explicit_rolling() -> None:
     source = patterned_clip(vs.GRAYS)
     arguments = {"radius": 2, "extractor_exp": 3, "fast": False}
     implicit = bm3dcuda.BM3Dv2(source, **arguments)
-    explicit = bm3dcuda.BM3Dv2(source, temporal_mode="fused", **arguments)
+    explicit = bm3dcuda.BM3Dv2(source, temporal_mode="rolling", **arguments)
     assert_frames_equal(implicit, explicit, (0, 5, 10))
+
+
+def test_default_radius_zero_uses_spatial_bm3d() -> None:
+    source = patterned_clip(vs.GRAYS, 3)
+    implicit = bm3dcuda.BM3Dv2(source, radius=0, fast=False, extractor_exp=6)
+    explicit = bm3dcuda.BM3D(source, radius=0, fast=False, extractor_exp=6)
+    assert_frames_equal(implicit, explicit, range(3))
+
+
+def test_final_frame_of_int_max_length_clip() -> None:
+    source = core.std.BlankClip(
+        width=8,
+        height=8,
+        format=vs.GRAYS,
+        length=np.iinfo(np.int32).max,
+    )
+    rolling = bm3dcuda.BM3Dv2(
+        source,
+        radius=1,
+        temporal_mode="rolling",
+        rolling_chunk=4,
+        fast=False,
+    )
+    frame = rolling.get_frame(rolling.num_frames - 1)
+    assert frame.width == 8
 
 
 @pytest.mark.parametrize("radius", [1, 2, 3, 4])
@@ -130,6 +158,26 @@ def test_reference_custom_parameters_and_unprocessed_planes() -> None:
             )
 
 
+def test_multi_chunk_cache_matches_legacy_on_random_access() -> None:
+    source = patterned_clip(vs.GRAYS, 17)
+    arguments = {
+        "radius": 2,
+        "extractor_exp": 6,
+        "block_step": 8,
+        "bm_range": 4,
+        "ps_range": 2,
+    }
+    legacy = bm3dcuda.BM3Dv2(source, temporal_mode="legacy", **arguments)
+    rolling = bm3dcuda.BM3Dv2(
+        source,
+        temporal_mode="rolling",
+        rolling_chunk=4,
+        rolling_cache_chunks=2,
+        **arguments,
+    )
+    assert_frames_equal(legacy, rolling, (0, 4, 8, 4, 0, 12, 8, 16, 12, 4))
+
+
 def test_zero_init_is_accepted_and_unprocessed_output_is_source() -> None:
     source = patterned_clip(vs.YUV444PS, 5)
     rolling = bm3dcuda.BM3Dv2(
@@ -159,6 +207,7 @@ def test_concurrent_requests_match_serial_output() -> None:
         "ps_range": 2,
         "temporal_mode": "rolling",
         "rolling_chunk": 4,
+        "rolling_cache_chunks": 2,
     }
     serial = bm3dcuda.BM3Dv2(source, **arguments)
     concurrent = bm3dcuda.BM3Dv2(source, **arguments)

--- a/tests/test_rtc_cuda_rolling.py
+++ b/tests/test_rtc_cuda_rolling.py
@@ -1,0 +1,171 @@
+import os
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import pytest
+import vapoursynth as vs
+
+
+PLUGIN_PATH = os.environ.get("BM3DCUDA_RTC_PLUGIN")
+if not PLUGIN_PATH:
+    pytest.skip(
+        "set BM3DCUDA_RTC_PLUGIN to an RTC plugin build",
+        allow_module_level=True,
+    )
+
+core = vs.core
+core.std.LoadPlugin(PLUGIN_PATH)
+bm3dcuda = core.bm3dcuda_rtc
+
+
+def patterned_clip(format_id: int, length: int = 11) -> vs.VideoNode:
+    blank = core.std.BlankClip(
+        width=32, height=24, format=format_id, length=length
+    )
+
+    def fill(n: int, frame: vs.VideoFrame) -> vs.VideoFrame:
+        output = frame.copy()
+        for plane in range(output.format.num_planes):
+            array = np.asarray(output[plane])
+            y, x = np.indices(array.shape)
+            array[:] = (
+                -0.1 * plane
+                + ((x * (3 + plane) + y * (5 + plane) + n * (7 + plane)) % 83)
+                / 255.0
+            )
+        output.props["TestFrame"] = n
+        return output
+
+    return core.std.ModifyFrame(blank, blank, fill)
+
+
+def assert_frames_equal(left: vs.VideoNode, right: vs.VideoNode, order) -> None:
+    for n in order:
+        left_frame = left.get_frame(n)
+        right_frame = right.get_frame(n)
+        assert right_frame.props["TestFrame"] == n
+        for plane in range(left_frame.format.num_planes):
+            assert np.array_equal(
+                np.asarray(left_frame[plane]), np.asarray(right_frame[plane])
+            ), (n, plane)
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        {"temporal_mode": "invalid", "radius": 1},
+        {"temporal_mode": "fused", "radius": 1, "rolling_chunk": 4},
+        {"temporal_mode": "legacy", "radius": 1, "rolling_chunk": 4},
+        {"temporal_mode": "rolling", "radius": 1, "rolling_chunk": 0},
+        {"temporal_mode": "rolling", "radius": 1, "rolling_chunk": 65},
+        {"temporal_mode": "rolling", "radius": 0},
+    ],
+)
+def test_selector_rejects_invalid_combinations(arguments) -> None:
+    source = patterned_clip(vs.GRAYS, 3)
+    with pytest.raises(vs.Error):
+        bm3dcuda.BM3Dv2(source, **arguments)
+
+
+def test_default_is_explicit_fused() -> None:
+    source = patterned_clip(vs.GRAYS)
+    arguments = {"radius": 2, "extractor_exp": 3, "fast": False}
+    implicit = bm3dcuda.BM3Dv2(source, **arguments)
+    explicit = bm3dcuda.BM3Dv2(source, temporal_mode="fused", **arguments)
+    assert_frames_equal(implicit, explicit, (0, 5, 10))
+
+
+@pytest.mark.parametrize("radius", [1, 2, 3, 4])
+@pytest.mark.parametrize("length", [1, 3, 11])
+def test_rolling_matches_deterministic_legacy(radius: int, length: int) -> None:
+    source = patterned_clip(vs.GRAYS, length)
+    arguments = {
+        "radius": radius,
+        "extractor_exp": 6,
+        "block_step": 8,
+        "bm_range": 4,
+        "ps_range": 2,
+    }
+    legacy = bm3dcuda.BM3Dv2(
+        source, temporal_mode="legacy", fast=False, **arguments
+    )
+    rolling = bm3dcuda.BM3Dv2(
+        source,
+        temporal_mode="rolling",
+        rolling_chunk=4,
+        fast=True,
+        **arguments,
+    )
+    order = list(range(length)) + list(reversed(range(length)))
+    assert_frames_equal(legacy, rolling, order)
+
+
+def test_reference_custom_parameters_and_unprocessed_planes() -> None:
+    source = patterned_clip(vs.YUV444PS, 9)
+    reference = core.std.Expr(source, expr=["x 0.01 +", "x 0.02 +", "x 0.03 +"])
+    arguments = {
+        "sigma": [3, 0, 0],
+        "radius": 2,
+        "extractor_exp": 6,
+        "bm_error_s": ["sad"],
+        "transform_2d_s": ["haar"],
+        "transform_1d_s": ["wht"],
+        "ref": reference,
+    }
+    legacy = bm3dcuda.BM3Dv2(source, temporal_mode="legacy", **arguments)
+    rolling = bm3dcuda.BM3Dv2(
+        source, temporal_mode="rolling", rolling_chunk=4, **arguments
+    )
+    for n in (0, 3, 4, 8):
+        source_frame = source.get_frame(n)
+        legacy_frame = legacy.get_frame(n)
+        rolling_frame = rolling.get_frame(n)
+        assert rolling_frame.props["TestFrame"] == n
+        assert np.array_equal(
+            np.asarray(legacy_frame[0]), np.asarray(rolling_frame[0])
+        )
+        for plane in (1, 2):
+            assert np.array_equal(
+                np.asarray(source_frame[plane]), np.asarray(rolling_frame[plane])
+            )
+
+
+def test_zero_init_is_accepted_and_unprocessed_output_is_source() -> None:
+    source = patterned_clip(vs.YUV444PS, 5)
+    rolling = bm3dcuda.BM3Dv2(
+        source,
+        sigma=[3, 0, 0],
+        radius=1,
+        temporal_mode="rolling",
+        rolling_chunk=2,
+        zero_init=False,
+    )
+    for n in (0, 2, 4):
+        source_frame = source.get_frame(n)
+        output_frame = rolling.get_frame(n)
+        for plane in (1, 2):
+            assert np.array_equal(
+                np.asarray(source_frame[plane]), np.asarray(output_frame[plane])
+            )
+
+
+def test_concurrent_requests_match_serial_output() -> None:
+    source = patterned_clip(vs.GRAYS, 17)
+    arguments = {
+        "radius": 3,
+        "extractor_exp": 6,
+        "block_step": 8,
+        "bm_range": 4,
+        "ps_range": 2,
+        "temporal_mode": "rolling",
+        "rolling_chunk": 4,
+    }
+    serial = bm3dcuda.BM3Dv2(source, **arguments)
+    concurrent = bm3dcuda.BM3Dv2(source, **arguments)
+    order = (0, 4, 8, 12, 16, 1, 5, 9, 13)
+    expected = {n: np.array(serial.get_frame(n)[0], copy=True) for n in order}
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        futures = {n: executor.submit(concurrent.get_frame, n) for n in order}
+        actual = {n: np.array(future.result()[0], copy=True) for n, future in futures.items()}
+    for n in order:
+        assert np.array_equal(expected[n], actual[n]), n

--- a/tests/test_static_cuda_rolling.py
+++ b/tests/test_static_cuda_rolling.py
@@ -23,8 +23,8 @@ def patterned_clip(format_id: int, length: int = 11) -> vs.VideoNode:
         width=32, height=24, format=format_id, length=length
     )
 
-    def fill(n: int, frame: vs.VideoFrame) -> vs.VideoFrame:
-        output = frame.copy()
+    def fill(n: int, f: vs.VideoFrame) -> vs.VideoFrame:
+        output = f.copy()
         for plane in range(output.format.num_planes):
             array = np.asarray(output[plane])
             y, x = np.indices(array.shape)
@@ -54,10 +54,13 @@ def assert_frames_equal(left: vs.VideoNode, right: vs.VideoNode, order) -> None:
     "arguments",
     [
         {"temporal_mode": "invalid", "radius": 1},
-        {"temporal_mode": "fused", "radius": 1, "rolling_chunk": 4},
+        {"temporal_mode": "fused", "radius": 1},
         {"temporal_mode": "legacy", "radius": 1, "rolling_chunk": 4},
+        {"temporal_mode": "legacy", "radius": 1, "rolling_cache_chunks": 2},
         {"temporal_mode": "rolling", "radius": 1, "rolling_chunk": 0},
         {"temporal_mode": "rolling", "radius": 1, "rolling_chunk": 65},
+        {"temporal_mode": "rolling", "radius": 1, "rolling_cache_chunks": 0},
+        {"temporal_mode": "rolling", "radius": 1, "rolling_cache_chunks": 65},
         {"temporal_mode": "rolling", "radius": 0},
     ],
 )
@@ -67,14 +70,37 @@ def test_selector_rejects_invalid_combinations(arguments) -> None:
         bm3dcuda.BM3Dv2(source, **arguments)
 
 
-def test_default_is_explicit_fused() -> None:
+def test_default_is_explicit_rolling() -> None:
     source = patterned_clip(vs.GRAYS)
     arguments = {"radius": 2, "extractor_exp": 3, "fast": False}
     implicit = bm3dcuda.BM3Dv2(source, **arguments)
-    explicit = bm3dcuda.BM3Dv2(
-        source, temporal_mode="fused", **arguments
-    )
+    explicit = bm3dcuda.BM3Dv2(source, temporal_mode="rolling", **arguments)
     assert_frames_equal(implicit, explicit, (0, 5, 10))
+
+
+def test_default_radius_zero_uses_spatial_bm3d() -> None:
+    source = patterned_clip(vs.GRAYS, 3)
+    implicit = bm3dcuda.BM3Dv2(source, radius=0, fast=False, extractor_exp=3)
+    explicit = bm3dcuda.BM3D(source, radius=0, fast=False, extractor_exp=3)
+    assert_frames_equal(implicit, explicit, range(3))
+
+
+def test_final_frame_of_int_max_length_clip() -> None:
+    source = core.std.BlankClip(
+        width=8,
+        height=8,
+        format=vs.GRAYS,
+        length=np.iinfo(np.int32).max,
+    )
+    rolling = bm3dcuda.BM3Dv2(
+        source,
+        radius=1,
+        temporal_mode="rolling",
+        rolling_chunk=4,
+        fast=False,
+    )
+    frame = rolling.get_frame(rolling.num_frames - 1)
+    assert frame.width == 8
 
 
 @pytest.mark.parametrize("radius", [1, 2, 3, 4])
@@ -131,6 +157,26 @@ def test_properties_and_unprocessed_planes_are_preserved() -> None:
             )
 
 
+def test_multi_chunk_cache_matches_legacy_on_random_access() -> None:
+    source = patterned_clip(vs.GRAYS, 17)
+    arguments = {
+        "radius": 2,
+        "extractor_exp": 3,
+        "block_step": 8,
+        "bm_range": 4,
+        "ps_range": 2,
+    }
+    legacy = bm3dcuda.BM3Dv2(source, temporal_mode="legacy", **arguments)
+    rolling = bm3dcuda.BM3Dv2(
+        source,
+        temporal_mode="rolling",
+        rolling_chunk=4,
+        rolling_cache_chunks=2,
+        **arguments,
+    )
+    assert_frames_equal(legacy, rolling, (0, 4, 8, 4, 0, 12, 8, 16, 12, 4))
+
+
 def test_concurrent_requests_match_serial_output() -> None:
     source = patterned_clip(vs.GRAYS, 17)
     arguments = {
@@ -141,6 +187,7 @@ def test_concurrent_requests_match_serial_output() -> None:
         "ps_range": 2,
         "temporal_mode": "rolling",
         "rolling_chunk": 4,
+        "rolling_cache_chunks": 2,
     }
     serial = bm3dcuda.BM3Dv2(source, **arguments)
     concurrent = bm3dcuda.BM3Dv2(source, **arguments)

--- a/tests/test_static_cuda_rolling.py
+++ b/tests/test_static_cuda_rolling.py
@@ -1,0 +1,164 @@
+import os
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import pytest
+import vapoursynth as vs
+
+
+PLUGIN_PATH = os.environ.get("BM3DCUDA_PLUGIN")
+if not PLUGIN_PATH:
+    pytest.skip(
+        "set BM3DCUDA_PLUGIN to a static CUDA plugin build",
+        allow_module_level=True,
+    )
+
+core = vs.core
+core.std.LoadPlugin(PLUGIN_PATH)
+bm3dcuda = core.bm3dcuda
+
+
+def patterned_clip(format_id: int, length: int = 11) -> vs.VideoNode:
+    blank = core.std.BlankClip(
+        width=32, height=24, format=format_id, length=length
+    )
+
+    def fill(n: int, frame: vs.VideoFrame) -> vs.VideoFrame:
+        output = frame.copy()
+        for plane in range(output.format.num_planes):
+            array = np.asarray(output[plane])
+            y, x = np.indices(array.shape)
+            array[:] = (
+                -0.1 * plane
+                + ((x * (3 + plane) + y * (5 + plane) + n * (7 + plane)) % 83)
+                / 255.0
+            )
+        output.props["TestFrame"] = n
+        return output
+
+    return core.std.ModifyFrame(blank, blank, fill)
+
+
+def assert_frames_equal(left: vs.VideoNode, right: vs.VideoNode, order) -> None:
+    for n in order:
+        left_frame = left.get_frame(n)
+        right_frame = right.get_frame(n)
+        assert right_frame.props["TestFrame"] == n
+        for plane in range(left_frame.format.num_planes):
+            assert np.array_equal(
+                np.asarray(left_frame[plane]), np.asarray(right_frame[plane])
+            ), (n, plane)
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        {"temporal_mode": "invalid", "radius": 1},
+        {"temporal_mode": "fused", "radius": 1, "rolling_chunk": 4},
+        {"temporal_mode": "legacy", "radius": 1, "rolling_chunk": 4},
+        {"temporal_mode": "rolling", "radius": 1, "rolling_chunk": 0},
+        {"temporal_mode": "rolling", "radius": 1, "rolling_chunk": 65},
+        {"temporal_mode": "rolling", "radius": 0},
+    ],
+)
+def test_selector_rejects_invalid_combinations(arguments) -> None:
+    source = patterned_clip(vs.GRAYS, 3)
+    with pytest.raises(vs.Error):
+        bm3dcuda.BM3Dv2(source, **arguments)
+
+
+def test_default_is_explicit_fused() -> None:
+    source = patterned_clip(vs.GRAYS)
+    arguments = {"radius": 2, "extractor_exp": 3, "fast": False}
+    implicit = bm3dcuda.BM3Dv2(source, **arguments)
+    explicit = bm3dcuda.BM3Dv2(
+        source, temporal_mode="fused", **arguments
+    )
+    assert_frames_equal(implicit, explicit, (0, 5, 10))
+
+
+@pytest.mark.parametrize("radius", [1, 2, 3, 4])
+@pytest.mark.parametrize("length", [1, 3, 11])
+def test_rolling_matches_deterministic_legacy(radius: int, length: int) -> None:
+    source = patterned_clip(vs.GRAYS, length)
+    arguments = {
+        "radius": radius,
+        "extractor_exp": 3,
+        "block_step": 8,
+        "bm_range": 4,
+        "ps_range": 2,
+    }
+    legacy = bm3dcuda.BM3Dv2(
+        source, temporal_mode="legacy", fast=False, **arguments
+    )
+    rolling = bm3dcuda.BM3Dv2(
+        source,
+        temporal_mode="rolling",
+        rolling_chunk=4,
+        fast=True,
+        **arguments,
+    )
+    order = list(range(length)) + list(reversed(range(length)))
+    assert_frames_equal(legacy, rolling, order)
+
+
+def test_properties_and_unprocessed_planes_are_preserved() -> None:
+    source = patterned_clip(vs.YUV444PS, 9)
+    arguments = {
+        "sigma": [3, 0, 0],
+        "radius": 1,
+        "extractor_exp": 3,
+    }
+    legacy = bm3dcuda.BM3Dv2(
+        source, temporal_mode="legacy", **arguments
+    )
+    rolling = bm3dcuda.BM3Dv2(
+        source, temporal_mode="rolling", rolling_chunk=4, **arguments
+    )
+
+    for n in (0, 3, 4, 8):
+        source_frame = source.get_frame(n)
+        legacy_frame = legacy.get_frame(n)
+        rolling_frame = rolling.get_frame(n)
+        assert rolling_frame.props["TestFrame"] == n
+        assert np.array_equal(
+            np.asarray(legacy_frame[0]), np.asarray(rolling_frame[0])
+        )
+        for plane in (1, 2):
+            assert np.array_equal(
+                np.asarray(source_frame[plane]),
+                np.asarray(rolling_frame[plane]),
+            )
+
+
+def test_concurrent_requests_match_serial_output() -> None:
+    source = patterned_clip(vs.GRAYS, 17)
+    arguments = {
+        "radius": 3,
+        "extractor_exp": 6,
+        "block_step": 8,
+        "bm_range": 4,
+        "ps_range": 2,
+        "temporal_mode": "rolling",
+        "rolling_chunk": 4,
+    }
+    serial = bm3dcuda.BM3Dv2(source, **arguments)
+    concurrent = bm3dcuda.BM3Dv2(source, **arguments)
+    order = (0, 4, 8, 12, 16, 1, 5, 9, 13)
+
+    expected = {
+        n: np.array(serial.get_frame(n)[0], copy=True)
+        for n in order
+    }
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        futures = {
+            n: executor.submit(concurrent.get_frame, n)
+            for n in order
+        }
+        actual = {
+            n: np.array(future.result()[0], copy=True)
+            for n, future in futures.items()
+        }
+
+    for n in order:
+        assert np.array_equal(expected[n], actual[n]), n


### PR DESCRIPTION
# Rolling temporal BM3Dv2 for CUDA and CUDA RTC

## Summary

This PR adds chunked rolling temporal execution to `BM3Dv2(radius > 0)` for
the static CUDA and CUDA RTC backends.

The supported temporal modes are now:

- `rolling` (default): builds aligned output chunks, performs aggregation on
  the GPU, and caches final VapourSynth frames on the host.
- `legacy`: composes the existing public `BM3D` and `VAggregate` filters.

The former fused temporal path has been removed. Public `BM3D` and
`VAggregate` remain available with their existing intermediate-frame behavior.

## API

- `rolling_chunk` accepts `[1, 64]` and defaults to `4`.
- `rolling_cache_chunks` accepts `[1, 64]`; omitted values start at one cached
  chunk and enable adaptive growth.
- `rolling_cache_limit` accepts `[1, 64]` and defaults to `16`.
- `fast` remains accepted for API compatibility, but rolling always uses one
  device resource, one stream, and one graph.
- An omitted temporal mode selects rolling. Explicit `temporal_mode="fused"`
  is rejected.
- Default `radius=0` still uses spatial BM3D. Explicit rolling mode requires
  a positive radius.

## Rolling design

For frame `n`, the cache key is aligned to
`floor(n / rolling_chunk) * rolling_chunk`. A miss requests the source and,
when present, reference halo around that chunk. The GPU graph then:

1. uploads the source and parameter staging buffers;
2. clears the chunk accumulator;
3. serially clears scratch, runs BM3D, and scatters each temporal center;
4. normalizes the accumulated output; and
5. transfers the final chunk frames back to pinned host memory.

The source slab contains `rolling_chunk + 4 * radius` frames and the graph
processes `rolling_chunk + 2 * radius` centers. Only valid frames are retained
for a partial final chunk. Cache hits clone final frames without GPU work.

Cache lookup and replacement use a shared mutex; staging and graph execution
use a separate resource mutex, so the single CUDA resource remains serialized
while independent VapourSynth requests can be scheduled with
`fmParallelRequests`.

Rolling output copies unprocessed planes and source frame properties. The
`zero_init` argument remains accepted for compatibility, but it does not alter
that behavior because rolling already produces final frames.

The RTC backend continues to accept its custom `bm_error_s`, `transform_2d_s`,
and `transform_1d_s` data parameters in rolling and legacy execution.

## Validation

The added static and RTC tests cover:

- default rolling versus explicit rolling;
- invalid modes and cache/chunk values;
- spatial radius-zero fallback;
- rolling versus legacy output for radii `1..4`, short clips, boundaries, and
  partial final chunks;
- GRAYS, YUV444PS, chroma, reference/final estimation, unprocessed planes, and
  frame properties;
- RTC custom data parameters and `zero_init` compatibility;
- random access, multi-chunk cache behavior, and concurrent requests.

Release builds of both plugins pass. Direct VapourSynth checks pass for default
rolling, explicit rolling, legacy equivalence, radius-zero fallback, public
`BM3D`/`VAggregate`, RTC custom parameters, references, and rejection of the
removed fused mode.

The repository test interpreter does not currently have `pytest` installed,
so the Python test modules were syntax-checked and the plugin behavior was
validated with equivalent direct VapourSynth scripts.

## Performance evaluation

The rolling design was evaluated against the former fused implementation with
a downstream temporal filter. The test used 640x360 GRAYS, radius `4`, 1024
output frames, eight requests, and `fast=False`:

| Backend | Downstream window | Former fused | Rolling | Rolling gain |
|---|---:|---:|---:|---:|
| Static CUDA | `maxr=2` | 273.75 fps | 358.54 fps | 1.31x |
| CUDA RTC | `maxr=2` | 273.63 fps | 360.07 fps | 1.32x |
| Static CUDA | `maxr=7` | 103.91 fps | 300.47 fps | 2.89x |
| CUDA RTC | `maxr=7` | 105.59 fps | 304.70 fps | 2.89x |

The source contained 719 frames and was looped to reach 1024 frames for this
performance-only run; the loop boundary is not a quality result.

Rolling trades some random-access miss work and host cache memory for lower
intermediate-frame traffic and substantially lower high-radius host memory
pressure. `rolling_chunk=4` is the default latency-oriented setting; larger
chunks can improve linear throughput, while `rolling_cache_limit` bounds the
cost of adaptive cache growth.

## Compatibility and scope

- CPU, HIP, and SYCL implementations are unchanged.
- Public CUDA and RTC `BM3D` and `VAggregate` remain separate APIs.
- Rolling is limited to temporal `BM3Dv2`; spatial `radius=0` remains on the
  normal BM3D path.
- RTC rolling uses the Driver API and does not reuse a static CUDA runtime
  graph.
